### PR TITLE
KJG-X: Anzeige Backend Online Status

### DIFF
--- a/lib/backend/backend_service.dart
+++ b/lib/backend/backend_service.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:kjg_muf_app/model/event.dart';
+import 'package:http/http.dart' as http;
+import 'package:crypto/crypto.dart';
+import 'package:kjg_muf_app/utils/shared_prefs.dart';
+
+class BackendService {
+    
+  final JsonDecoder _decoder = const JsonDecoder();
+  final JsonEncoder _encoder = const JsonEncoder();
+
+  Map<String, String> headers = {"content-type": "text/json"};
+  Map<String, String> cookies = {};
+
+  Future<bool> getBackendStatus() async {
+    http.Response response;
+    try {
+      response = await _get("http://kjg.thomas-barein.de:3000/api/status");
+    } on Exception catch (_) {
+      return false;
+    }
+    return response.statusCode >= 200 && response.statusCode <= 300;
+  }
+
+  Future<http.Response> _get(String url) {
+    return http.get(Uri.parse(url), headers: headers).then((http.Response response) {
+
+      final String res = response.body;
+      final int statusCode = response.statusCode;
+
+      _updateCookie(response);
+
+      if (statusCode < 200 || statusCode > 400) {
+        throw Exception("Error while fetching data");
+      }
+      return response;
+    });
+  }
+
+  Future<http.Response> _post(String url, {body, encoding}) {
+    return http
+        .post(Uri.parse(url), body: _encoder.convert(body), headers: headers, encoding: encoding)
+        .then((http.Response response) {
+      final String res = response.body;
+      final int statusCode = response.statusCode;
+
+      _updateCookie(response);
+
+      if (statusCode < 200 || statusCode > 400) {
+        throw Exception("Error while fetching data");
+      }
+      return response;
+    });
+  }
+
+  void _updateCookie(http.Response response) {
+    String? allSetCookie = response.headers['set-cookie'];
+
+    if (allSetCookie != null) {
+      var setCookies = allSetCookie.split(',');
+
+      for (var setCookie in setCookies) {
+        var cookies = setCookie.split(';');
+
+        for (var cookie in cookies) {
+          _setCookie(cookie);
+        }
+      }
+
+      headers['cookie'] = _generateCookieHeader();
+    }
+  }
+
+  void _setCookie(String rawCookie) {
+    if (rawCookie.isNotEmpty) {
+      var keyValue = rawCookie.split('=');
+      if (keyValue.length == 2) {
+        var key = keyValue[0].trim();
+        var value = keyValue[1];
+
+        // ignore keys that aren't cookies
+        if (key == 'path' || key == 'expires') {
+          return;
+        }
+
+        cookies[key] = value;
+      }
+    }
+  }
+
+  String _generateCookieHeader() {
+    String cookie = "";
+
+    for (var key in cookies.keys) {
+      if (cookie.isNotEmpty) {
+        cookie += ";";
+      }
+      cookie += "$key=${cookies[key]}";
+    }
+
+    return cookie;
+  }
+
+}

--- a/lib/backend/backend_service.dart
+++ b/lib/backend/backend_service.dart
@@ -16,7 +16,7 @@ class BackendService {
   Future<bool> getBackendStatus() async {
     http.Response response;
     try {
-      response = await _get("http://kjg.thomas-barein.de:3000/api/status");
+      response = await _get("http://kjg.thomas-barein.de/api/status");
     } on Exception catch (_) {
       return false;
     }

--- a/lib/backend/backend_service.dart
+++ b/lib/backend/backend_service.dart
@@ -5,6 +5,8 @@ import 'package:http/http.dart' as http;
 import 'package:crypto/crypto.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 
+const String backendBaseURL = "http://kjg.thomas-barein.de/api";
+
 class BackendService {
     
   final JsonDecoder _decoder = const JsonDecoder();
@@ -16,7 +18,7 @@ class BackendService {
   Future<bool> getBackendStatus() async {
     http.Response response;
     try {
-      response = await _get("http://kjg.thomas-barein.de/api/status");
+      response = await _get("$backendBaseURL/status");
     } on Exception catch (_) {
       return false;
     }

--- a/lib/backend/mida_service.dart
+++ b/lib/backend/mida_service.dart
@@ -4,6 +4,8 @@ import 'package:http/http.dart' as http;
 import 'package:crypto/crypto.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 
+const String midaBaseURL = "https://mida.kjg.de/DVMuenchenundFreising";
+
 class MidaService {
     
   final JsonDecoder _decoder = const JsonDecoder();
@@ -14,7 +16,7 @@ class MidaService {
 
   Future<bool> verifyLogin(String username, String password) async {
     final passwordHash = _generateMd5(password);
-    final response = await _post("https://mida.kjg.de/DVMuenchenundFreising/?api=VerifyLogin&token=A/$username/$passwordHash&user=$username&password=$password");
+    final response = await _post("$midaBaseURL/?api=VerifyLogin&token=A/$username/$passwordHash&user=$username&password=$password");
 
     if (response.statusCode == 200) {
       try {
@@ -37,11 +39,11 @@ class MidaService {
   }
 
   Future<http.Response> getGroups() {
-    return _get("https://mida.kjg.de/DVMuenchenundFreising/?api=GetGroups&token=A/fabian.thomas-barein/70c1941a720039395c705ae93f858a3d");
+    return _get("$midaBaseURL/?api=GetGroups&token=A/fabian.thomas-barein/70c1941a720039395c705ae93f858a3d");
   }
 
   Future<List<Event>> getEvents() async {
-    final response = await _get("https://mida.kjg.de/DVMuenchenundFreising/?api=GetEvents&jahr=zukunft&restriction=mandant=503");
+    final response = await _get("$midaBaseURL/?api=GetEvents&jahr=zukunft&restriction=mandant=503");
 
     if (response.statusCode == 200) {
       List jsonResponse = json.decode(response.body);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/constants/palette.dart';
 import 'package:kjg_muf_app/main.viewmodel.dart';
+import 'package:kjg_muf_app/ui/screens/backend_status.dart';
 import 'package:kjg_muf_app/ui/screens/event_list.dart';
 import 'package:kjg_muf_app/ui/screens/login_screen.dart';
 import 'package:provider/provider.dart';
@@ -76,7 +77,16 @@ class _MyHomePageState extends State<MyHomePage> {
                     onTap: () {
                       model.logoutUser();
                     },
-                  )
+                  ),
+                ListTile(
+                  title: const Text("Backend Status"),
+                  onTap: () {
+                    Navigator.pop(context);
+                    Navigator.of(context)
+                        .push(MaterialPageRoute(
+                        builder: (context) => const BackendStatus()));
+                  },
+                )
               ],
             ),
           ),

--- a/lib/ui/screens/backend_status.dart
+++ b/lib/ui/screens/backend_status.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:kjg_muf_app/backend/backend_service.dart';
+
+class BackendStatus extends StatelessWidget {
+  const BackendStatus({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Backend Status"),
+      ),
+      body: Center(
+        child: FutureBuilder<bool>(
+          future: BackendService().getBackendStatus(),
+          builder: (context, snapshot) {
+            if (snapshot.hasData &&
+                snapshot.connectionState == ConnectionState.done) {
+              return Text(snapshot.data == true
+                  ? "Backend Online!"
+                  : "Backend Offline!");
+            } else {
+              return const CircularProgressIndicator();
+            }
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Ich habe mal ein ganz simples node Backend in Typescript aufgesetzt (https://github.com/fabitb/KjG-MuF-Backend) und aufm Server deployed. Es gibt aktuell schonmal einen status endpoint, um abzufragen, ob der Server online ist. Kann unter http://kjg.thomas-barein.de/api/status erreicht werden. Ich hab temporär erstmal ne Subdomain von einer Domain von mir auf dem Server zeigen lassen, um auch noch nen SSL Zertifikat über lets encrypt erstellen zu können. Aber kommt noch irgendwann.

Hab auf jedenfall in die App mal eine Seite gebaut, um den Status vom Backend abfragen zu können. Damit ist der erste Call schonmal drin 😄 