### PR TITLE
KJG-45 Calendar Export in WebView

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     package="de.kjg.kjg_muf_app">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
 
     <queries>
         <intent>
@@ -15,6 +17,10 @@
         <intent>
             <action android:name="android.intent.action.SEND" />
             <data android:mimeType="*/*" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.INSERT" />
+            <data android:mimeType="vnd.android.cursor.item/event" />
         </intent>
     </queries>
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,7 +49,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
-    <string>Events aus der MiDa direkt zum Kalender hinzufuegen</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Events aus der MiDa direkt zum Kalender hinzufügen</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Events aus der MiDa direkt zum Kalender hinzufügen</string>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,5 +49,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+    <string>Events aus der MiDa direkt zum Kalender hinzufuegen</string>
 </dict>
 </plist>

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -15,6 +15,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:map_launcher/map_launcher.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:add_2_calendar/add_2_calendar.dart' as calendar;
 
 class EventDetailScreen extends StatelessWidget {
   final Event event;
@@ -27,6 +28,24 @@ class EventDetailScreen extends StatelessWidget {
   Future<Location> getLocationFromAddress() async {
     var locations = await locationFromAddress(event.location);
     return locations.first;
+  }
+
+  void _addToCalendar() {
+    final event = this.event;
+    if (event != null) {
+      // Adds event link to the end of the description (not as modal)
+      // duration 1 hour if end time equals start time
+      final calendar.Event calendarEvent = calendar.Event(
+          title: event.title,
+          description:
+              "${event.description}\n\n${event.eventUrl.replaceAll("&dialog=1", "")}",
+          location: event.location,
+          startDate: event.startDateAndTime,
+          endDate: event.endDate.compareTo(event.startDateAndTime) == 0
+              ? event.endDate.add(const Duration(hours: 1))
+              : event.endDate);
+      calendar.Add2Calendar.addEvent2Cal(calendarEvent);
+    }
   }
 
   @override
@@ -194,7 +213,10 @@ class EventDetailScreen extends StatelessWidget {
                                   topRight: Radius.circular(16.0))),
                           builder: (BuildContext context) {
                             return MidaWebViewScreen(
-                                url: event.eventUrl, token: token);
+                              url: event.eventUrl,
+                              token: token,
+                              addToCalendar: _addToCalendar,
+                            );
                           })
                       .whenComplete(
                           () => model.isUserRegisteredForEvent(event.eventID));

--- a/lib/ui/screens/mida_webview_screen.dart
+++ b/lib/ui/screens/mida_webview_screen.dart
@@ -4,10 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 class MidaWebViewScreen extends StatelessWidget {
-  MidaWebViewScreen({super.key, required this.url, required this.token});
+  MidaWebViewScreen(
+      {super.key, required this.url, required this.token, this.addToCalendar});
 
   final String url;
   final String? token;
+  final Function? addToCalendar;
 
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers = {
     Factory(() => EagerGestureRecognizer())
@@ -33,6 +35,30 @@ class MidaWebViewScreen extends StatelessWidget {
                           JsAlertResponse(handledByClient: true));
                     }
                     return Future.value(null);
+                  },
+                  onWebViewCreated: (controller) {
+                    // inject custom handler (callback to flutter in js)
+                    controller.addJavaScriptHandler(
+                        handlerName: "addToCalendar",
+                        callback: (args) {
+                          addToCalendar!();
+                        });
+                  },
+                  onLoadStop: (controller, url) {
+                    // Remove link from all calendar buttons and call handler instead
+                    controller.evaluateJavascript(source: """
+                      function flutterAddToCalendar() {
+                        window.flutter_inappwebview.callHandler("addToCalendar");
+                      }
+                      
+                      // find all buttons that use mida calendar export action
+                      let buttons = document.querySelectorAll("a[href^='./?action=events_exportoutlook']");
+                      
+                      buttons.forEach((btn) => {
+                        btn.removeAttribute("href");
+                        btn.onclick = flutterAddToCalendar;
+                      });                
+                    """);
                   },
                   gestureRecognizers: gestureRecognizers,
                   initialUrlRequest: URLRequest(

--- a/lib/ui/screens/mida_webview_screen.dart
+++ b/lib/ui/screens/mida_webview_screen.dart
@@ -30,7 +30,7 @@ class MidaWebViewScreen extends StatelessWidget {
                     controller.addJavaScriptHandler(
                         handlerName: "addToCalendar",
                         callback: (args) {
-                          addToCalendar!();
+                          addToCalendar?.call();
                         });
 
                     // close popup handler

--- a/lib/ui/screens/mida_webview_screen.dart
+++ b/lib/ui/screens/mida_webview_screen.dart
@@ -24,24 +24,20 @@ class MidaWebViewScreen extends StatelessWidget {
           const CloseButton(),
           Expanded(
               child: InAppWebView(
-                  onCloseWindow: (controller) {
-                    Navigator.of(context).pop();
-                  },
-                  onJsAlert: (controller, jsAlertRequest) {
-                    if (jsAlertRequest.message ==
-                        "Skripte können keine Fenster schließen, die nicht von ihnen geöffnet wurden.") {
-                      Navigator.of(context).pop();
-                      return Future.value(
-                          JsAlertResponse(handledByClient: true));
-                    }
-                    return Future.value(null);
-                  },
                   onWebViewCreated: (controller) {
-                    // inject custom handler (callback to flutter in js)
+                    // inject custom handlers (callback to flutter in JS)
+                    // add to calendar handler
                     controller.addJavaScriptHandler(
                         handlerName: "addToCalendar",
                         callback: (args) {
                           addToCalendar!();
+                        });
+
+                    // close popup handler
+                    controller.addJavaScriptHandler(
+                        handlerName: "closePopup",
+                        callback: (args) {
+                          Navigator.of(context).pop();
                         });
                   },
                   onLoadStop: (controller, url) {
@@ -58,6 +54,13 @@ class MidaWebViewScreen extends StatelessWidget {
                         btn.removeAttribute("href");
                         btn.onclick = flutterAddToCalendar;
                       });                
+                    """);
+
+                    // override mida CancelPopup function
+                    controller.evaluateJavascript(source: """
+                      CancelPopup = () => {
+                        window.flutter_inappwebview.callHandler("closePopup");
+                      }
                     """);
                   },
                   gestureRecognizers: gestureRecognizers,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   path_provider: ^2.1.1
   skeletonizer: ^0.8.0
   add_2_calendar: ^2.2.5
+  html: ^0.15.4
 
 dev_dependencies:
   flutter_launcher_icons: "^0.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   isar_flutter_libs: ^3.1.0+1
   path_provider: ^2.1.1
   skeletonizer: ^0.8.0
+  add_2_calendar: ^2.2.5
 
 dev_dependencies:
   flutter_launcher_icons: "^0.10.0"


### PR DESCRIPTION
Injekted js um "Zum Kalender hinzufügen" Knöpfe in mida webviews abzufangen und Event stattdessen zum Systemkalender hinzuzufügen.

addToCalendar Methode ist in event_detail_screen, falls dort auch noch ein Knopf direkt in Flutter dazukommen soll. Die Eventdaten müssten sonst auch in irgendeiner Form zum WebView, das fand ich so schöner als das event zu übergeben.

Außerdem das Abfangen von "Schließen" Knopf verbessert (KJG-52)

Getestet nur auf Android, kein Plan ob das Info.plist richtig ist und damit funktioniert (in der Documentation von add_2_cal stehen keys die deprecated sind: https://pub.dev/packages/add_2_calendar )
Eventuell muss man für language support bei iOS (beim Fenster zum Event speichern) auch noch was hinzufügen (siehe Dokumentation).