### PR TITLE
KJG-54 show event image in EventDetailScreen

### DIFF
--- a/lib/model/event.dart
+++ b/lib/model/event.dart
@@ -10,6 +10,7 @@ class Event {
   final String eventUrl;
   final int durationDays;
   final List<String> attachments;
+  final String imageUrl;
 
   const Event(
       {required this.eventID,
@@ -22,7 +23,8 @@ class Event {
       required this.contactEmail,
       required this.eventUrl,
       required this.durationDays,
-      required this.attachments});
+      required this.attachments,
+      required this.imageUrl});
 
   DateTime get endDate =>
       startDateAndTime.add(Duration(days: durationDays - 1));
@@ -44,6 +46,9 @@ class Event {
       endTime = timeInput.split('-')[1];
     }
     String eventUrl = json['url'] + json['link'];
+    String imageURL = (json['bild'] as String).isEmpty
+        ? ""
+        : json['url'] + "/?download=" + json['bild'];
     List<String> attachments = (json['attachments'] as String)
         .split("\n")
         .where((element) => element.isNotEmpty)
@@ -63,7 +68,8 @@ class Event {
         contactEmail: json['kontaktemail'],
         eventUrl: eventUrl,
         durationDays: int.parse(json['anzahltage']),
-        attachments: attachments);
+        attachments: attachments,
+        imageUrl: imageURL);
   }
 
   static List<Event> createFakeData() {
@@ -79,6 +85,7 @@ class Event {
             contactEmail: "",
             eventUrl: "",
             durationDays: 1,
-            attachments: []));
+            attachments: [],
+            imageUrl: ""));
   }
 }

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -172,6 +172,20 @@ class EventDetailScreen extends StatelessWidget {
                                     }),
                               )
                             : const SizedBox(),
+                        event.imageUrl.isNotEmpty
+                            ? Card(
+                                child: AspectRatio(
+                                  aspectRatio: 1,
+                                  child: Stack(
+                                    alignment: Alignment.center,
+                                    children: [
+                                      const CircularProgressIndicator(),
+                                      Image.network(event.imageUrl),
+                                    ],
+                                  ),
+                                ),
+                              )
+                            : const SizedBox(),
                         InkWell(
                           onTap: () {
                             model.openUrl("mailto:${event.contactEmail}");

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -174,6 +174,7 @@ class EventDetailScreen extends StatelessWidget {
                             : const SizedBox(),
                         event.imageUrl.isNotEmpty
                             ? Card(
+                                clipBehavior: Clip.antiAlias,
                                 child: AspectRatio(
                                   aspectRatio: 1,
                                   child: Stack(

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -19,6 +19,8 @@ import 'package:add_2_calendar/add_2_calendar.dart' as calendar;
 import 'dart:io' show Platform;
 import 'package:html/parser.dart';
 
+import 'fullscreen_image.dart';
+
 class EventDetailScreen extends StatelessWidget {
   final Event event;
 
@@ -173,16 +175,23 @@ class EventDetailScreen extends StatelessWidget {
                               )
                             : const SizedBox(),
                         event.imageUrl.isNotEmpty
-                            ? Card(
-                                clipBehavior: Clip.antiAlias,
-                                child: AspectRatio(
-                                  aspectRatio: 1,
-                                  child: Stack(
-                                    alignment: Alignment.center,
-                                    children: [
-                                      const CircularProgressIndicator(),
-                                      Image.network(event.imageUrl),
-                                    ],
+                            ? InkWell(
+                                onTap: () {
+                                  Navigator.of(context).push(MaterialPageRoute(
+                                      builder: (context) => FullscreenImage(
+                                          url: event.imageUrl)));
+                                },
+                                child: Card(
+                                  clipBehavior: Clip.antiAlias,
+                                  child: AspectRatio(
+                                    aspectRatio: 1,
+                                    child: Stack(
+                                      alignment: Alignment.center,
+                                      children: [
+                                        const CircularProgressIndicator(),
+                                        Image.network(event.imageUrl),
+                                      ],
+                                    ),
                                   ),
                                 ),
                               )

--- a/lib/ui/screens/fullscreen_image.dart
+++ b/lib/ui/screens/fullscreen_image.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+
+class FullscreenImage extends StatelessWidget {
+  final String url;
+
+  const FullscreenImage({super.key, required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: PhotoView(
+        backgroundDecoration: BoxDecoration(
+          color: Theme.of(context).scaffoldBackgroundColor,
+        ),
+        minScale: PhotoViewComputedScale.contained,
+        maxScale: PhotoViewComputedScale.covered * 2,
+        imageProvider: NetworkImage(url),
+      ),
+    );
+  }
+
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   skeletonizer: ^0.8.0
   add_2_calendar: ^2.2.5
   html: ^0.15.4
+  photo_view: ^0.14.0
 
 dev_dependencies:
   flutter_launcher_icons: "^0.10.0"


### PR DESCRIPTION
Speichert die Bild-URL im Event, wenn sie existiert.

Zeigt Bild im EventDetailScreen mit der URL an.
In AspectRatio um ein Quadrat Platz zu reservieren, weil die Größe und das Seitenverhältnis des Bildes nicht bekannt ist (ist sehr unterschiedlich, teils quer, teils hoch, teils quadratisch). Ohne das würde das Bild während dem Laden keinen Platz einnehmen und die Kontakt-Karte erst nachdem das Bild geladen ist nach unten rutschen. Alternativ könnte man das Bild auch als allerletztes anzeigen, dann ist es egal wenn der Platz nicht von Anfang an reserviert ist (ich fand es aber nach der Beschreibung schöner).