### PR TITLE
KJG-47 Persönliche Veranstaltungen

### DIFF
--- a/lib/backend/mida_service.dart
+++ b/lib/backend/mida_service.dart
@@ -41,7 +41,7 @@ class MidaService {
       try {
         Map<String, dynamic> jsonResponse = json.decode(response.body);
         if (jsonResponse['error'] != null) {
-          print(jsonResponse['error']);
+          debugPrint(jsonResponse['error']);
           return false;
         }
       } catch (error) {

--- a/lib/constants/strings.dart
+++ b/lib/constants/strings.dart
@@ -5,4 +5,11 @@ class Strings {
       "https://mida.kjg.de/DVMuenchenundFreising/?module=shop";
   static const contactEmailAddress = "info@kjg-muenchen.de";
   static const dataPrivacyLink = "https://muenchen.kjg.de/datenschutz-kjg-app/";
+
+  // table headers returned form MiDa CSV Export
+  static const midaCsvLinkHeader = "Link";
+  static const midaCsvStatusHeader = "Status";
+  static const midaCsvPlaceHeader = "Ort";
+  static const midaCsvTitleHeader = "Veranstaltung";
+  static const midaCsvDateHeader = "Datum";
 }

--- a/lib/database/db_service.dart
+++ b/lib/database/db_service.dart
@@ -1,4 +1,5 @@
 import 'package:isar/isar.dart';
+import 'package:kjg_muf_app/model/event.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'model/game_model.dart';
@@ -24,6 +25,12 @@ class DBService {
   Future<List<GameModel>> getAllGames() async {
     final isar = await db;
     return await isar.gameModels.where().findAll();
+  }
+
+  // This is where I would put my cache
+  // IF I HAD ONE
+  Future<List<Event>> getCachedEvents() async {
+    return Event.createFakeData();
   }
 
   Future<Isar> openDB() async {

--- a/lib/database/db_service.dart
+++ b/lib/database/db_service.dart
@@ -30,7 +30,7 @@ class DBService {
 
   Future<List<EventModel>> getCachedEvents() async {
     final isar = await db;
-    return await isar.eventModels.where().findAll();
+    return await isar.eventModels.where().sortByStartDateAndTime().findAll();
   }
 
   Future<void> cacheEvents(

--- a/lib/database/model/event_model.dart
+++ b/lib/database/model/event_model.dart
@@ -1,0 +1,71 @@
+import 'package:isar/isar.dart';
+import 'package:kjg_muf_app/model/event.dart';
+
+part 'event_model.g.dart';
+
+@collection
+class EventModel {
+  late Id id;
+  late String eventID;
+  late String title;
+  late DateTime startDateAndTime;
+  late DateTime? endTime;
+  late String location;
+  late String description;
+  late String contactName;
+  late String contactEmail;
+  late String eventUrl;
+  late int durationDays;
+  late List<String> attachments;
+  late String imageUrl;
+  late bool registered;
+
+  EventModel(
+      this.id,
+      this.eventID,
+      this.title,
+      this.startDateAndTime,
+      this.endTime,
+      this.location,
+      this.description,
+      this.contactName,
+      this.contactEmail,
+      this.eventUrl,
+      this.durationDays,
+      this.attachments,
+      this.imageUrl,
+      this.registered);
+
+  factory EventModel.fromEvent(Event event, bool registered) {
+    return EventModel(
+        int.parse(event.eventID),
+        event.eventID,
+        event.title,
+        event.startDateAndTime,
+        event.endTime,
+        event.location,
+        event.description,
+        event.contactName,
+        event.contactEmail,
+        event.eventUrl,
+        event.durationDays,
+        event.attachments,
+        event.imageUrl,
+        registered);
+  }
+
+  Event toEvent() {
+    return Event(
+        eventID: eventID,
+        title: title,
+        startDateAndTime: startDateAndTime,
+        location: location,
+        description: description,
+        contactName: contactName,
+        contactEmail: contactEmail,
+        eventUrl: eventUrl,
+        durationDays: durationDays,
+        attachments: attachments,
+        imageUrl: imageUrl);
+  }
+}

--- a/lib/database/model/event_model.g.dart
+++ b/lib/database/model/event_model.g.dart
@@ -1,0 +1,2334 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'event_model.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetEventModelCollection on Isar {
+  IsarCollection<EventModel> get eventModels => this.collection();
+}
+
+const EventModelSchema = CollectionSchema(
+  name: r'EventModel',
+  id: 3380270723020586526,
+  properties: {
+    r'attachments': PropertySchema(
+      id: 0,
+      name: r'attachments',
+      type: IsarType.stringList,
+    ),
+    r'contactEmail': PropertySchema(
+      id: 1,
+      name: r'contactEmail',
+      type: IsarType.string,
+    ),
+    r'contactName': PropertySchema(
+      id: 2,
+      name: r'contactName',
+      type: IsarType.string,
+    ),
+    r'description': PropertySchema(
+      id: 3,
+      name: r'description',
+      type: IsarType.string,
+    ),
+    r'durationDays': PropertySchema(
+      id: 4,
+      name: r'durationDays',
+      type: IsarType.long,
+    ),
+    r'endTime': PropertySchema(
+      id: 5,
+      name: r'endTime',
+      type: IsarType.dateTime,
+    ),
+    r'eventID': PropertySchema(
+      id: 6,
+      name: r'eventID',
+      type: IsarType.string,
+    ),
+    r'eventUrl': PropertySchema(
+      id: 7,
+      name: r'eventUrl',
+      type: IsarType.string,
+    ),
+    r'imageUrl': PropertySchema(
+      id: 8,
+      name: r'imageUrl',
+      type: IsarType.string,
+    ),
+    r'location': PropertySchema(
+      id: 9,
+      name: r'location',
+      type: IsarType.string,
+    ),
+    r'registered': PropertySchema(
+      id: 10,
+      name: r'registered',
+      type: IsarType.bool,
+    ),
+    r'startDateAndTime': PropertySchema(
+      id: 11,
+      name: r'startDateAndTime',
+      type: IsarType.dateTime,
+    ),
+    r'title': PropertySchema(
+      id: 12,
+      name: r'title',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _eventModelEstimateSize,
+  serialize: _eventModelSerialize,
+  deserialize: _eventModelDeserialize,
+  deserializeProp: _eventModelDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _eventModelGetId,
+  getLinks: _eventModelGetLinks,
+  attach: _eventModelAttach,
+  version: '3.1.0+1',
+);
+
+int _eventModelEstimateSize(
+  EventModel object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.attachments.length * 3;
+  {
+    for (var i = 0; i < object.attachments.length; i++) {
+      final value = object.attachments[i];
+      bytesCount += value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.contactEmail.length * 3;
+  bytesCount += 3 + object.contactName.length * 3;
+  bytesCount += 3 + object.description.length * 3;
+  bytesCount += 3 + object.eventID.length * 3;
+  bytesCount += 3 + object.eventUrl.length * 3;
+  bytesCount += 3 + object.imageUrl.length * 3;
+  bytesCount += 3 + object.location.length * 3;
+  bytesCount += 3 + object.title.length * 3;
+  return bytesCount;
+}
+
+void _eventModelSerialize(
+  EventModel object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeStringList(offsets[0], object.attachments);
+  writer.writeString(offsets[1], object.contactEmail);
+  writer.writeString(offsets[2], object.contactName);
+  writer.writeString(offsets[3], object.description);
+  writer.writeLong(offsets[4], object.durationDays);
+  writer.writeDateTime(offsets[5], object.endTime);
+  writer.writeString(offsets[6], object.eventID);
+  writer.writeString(offsets[7], object.eventUrl);
+  writer.writeString(offsets[8], object.imageUrl);
+  writer.writeString(offsets[9], object.location);
+  writer.writeBool(offsets[10], object.registered);
+  writer.writeDateTime(offsets[11], object.startDateAndTime);
+  writer.writeString(offsets[12], object.title);
+}
+
+EventModel _eventModelDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = EventModel(
+    id,
+    reader.readString(offsets[6]),
+    reader.readString(offsets[12]),
+    reader.readDateTime(offsets[11]),
+    reader.readDateTimeOrNull(offsets[5]),
+    reader.readString(offsets[9]),
+    reader.readString(offsets[3]),
+    reader.readString(offsets[2]),
+    reader.readString(offsets[1]),
+    reader.readString(offsets[7]),
+    reader.readLong(offsets[4]),
+    reader.readStringList(offsets[0]) ?? [],
+    reader.readString(offsets[8]),
+    reader.readBool(offsets[10]),
+  );
+  return object;
+}
+
+P _eventModelDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringList(offset) ?? []) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readString(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
+      return (reader.readLong(offset)) as P;
+    case 5:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 6:
+      return (reader.readString(offset)) as P;
+    case 7:
+      return (reader.readString(offset)) as P;
+    case 8:
+      return (reader.readString(offset)) as P;
+    case 9:
+      return (reader.readString(offset)) as P;
+    case 10:
+      return (reader.readBool(offset)) as P;
+    case 11:
+      return (reader.readDateTime(offset)) as P;
+    case 12:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _eventModelGetId(EventModel object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _eventModelGetLinks(EventModel object) {
+  return [];
+}
+
+void _eventModelAttach(IsarCollection<dynamic> col, Id id, EventModel object) {
+  object.id = id;
+}
+
+extension EventModelQueryWhereSort
+    on QueryBuilder<EventModel, EventModel, QWhere> {
+  QueryBuilder<EventModel, EventModel, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension EventModelQueryWhere
+    on QueryBuilder<EventModel, EventModel, QWhereClause> {
+  QueryBuilder<EventModel, EventModel, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension EventModelQueryFilter
+    on QueryBuilder<EventModel, EventModel, QFilterCondition> {
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'attachments',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'attachments',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'attachments',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'attachments',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsElementIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'attachments',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      attachmentsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'attachments',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'contactEmail',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'contactEmail',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'contactEmail',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'contactEmail',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactEmailIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'contactEmail',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'contactName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'contactName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'contactName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'contactName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      contactNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'contactName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'description',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'description',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'description',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'description',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      descriptionIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'description',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      durationDaysEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'durationDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      durationDaysGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'durationDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      durationDaysLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'durationDays',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      durationDaysBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'durationDays',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> endTimeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'endTime',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      endTimeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'endTime',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> endTimeEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'endTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      endTimeGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'endTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> endTimeLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'endTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> endTimeBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'endTime',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventIDGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'eventID',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'eventID',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'eventID',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventIDIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'eventID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventIDIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'eventID',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventUrlGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'eventUrl',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventUrlStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'eventUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> eventUrlMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'eventUrl',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'eventUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      eventUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'eventUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      imageUrlGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'imageUrl',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      imageUrlStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'imageUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> imageUrlMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'imageUrl',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      imageUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'imageUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      imageUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'imageUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'location',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'location',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> locationMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'location',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'location',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'location',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> registeredEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'registered',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      startDateAndTimeEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'startDateAndTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      startDateAndTimeGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'startDateAndTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      startDateAndTimeLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'startDateAndTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      startDateAndTimeBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'startDateAndTime',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'title',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'title',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'title',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> titleIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'title',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      titleIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'title',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension EventModelQueryObject
+    on QueryBuilder<EventModel, EventModel, QFilterCondition> {}
+
+extension EventModelQueryLinks
+    on QueryBuilder<EventModel, EventModel, QFilterCondition> {}
+
+extension EventModelQuerySortBy
+    on QueryBuilder<EventModel, EventModel, QSortBy> {
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByContactEmail() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactEmail', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByContactEmailDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactEmail', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByContactName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByContactNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByDescription() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByDescriptionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByDurationDays() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationDays', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByDurationDaysDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationDays', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'endTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEndTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'endTime', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEventID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEventIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEventUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByEventUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByImageUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'imageUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByImageUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'imageUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByLocation() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'location', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByLocationDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'location', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByRegistered() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'registered', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByRegisteredDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'registered', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByStartDateAndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startDateAndTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy>
+      sortByStartDateAndTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startDateAndTime', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByTitle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByTitleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+}
+
+extension EventModelQuerySortThenBy
+    on QueryBuilder<EventModel, EventModel, QSortThenBy> {
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByContactEmail() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactEmail', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByContactEmailDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactEmail', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByContactName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByContactNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'contactName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByDescription() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByDescriptionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'description', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByDurationDays() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationDays', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByDurationDaysDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationDays', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'endTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEndTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'endTime', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEventID() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventID', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEventIDDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventID', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEventUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByEventUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'eventUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByImageUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'imageUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByImageUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'imageUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByLocation() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'location', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByLocationDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'location', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByRegistered() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'registered', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByRegisteredDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'registered', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByStartDateAndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startDateAndTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy>
+      thenByStartDateAndTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'startDateAndTime', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByTitle() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByTitleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'title', Sort.desc);
+    });
+  }
+}
+
+extension EventModelQueryWhereDistinct
+    on QueryBuilder<EventModel, EventModel, QDistinct> {
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByAttachments() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'attachments');
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByContactEmail(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'contactEmail', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByContactName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'contactName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByDescription(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'description', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByDurationDays() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'durationDays');
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByEndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'endTime');
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByEventID(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'eventID', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByEventUrl(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'eventUrl', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByImageUrl(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'imageUrl', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByLocation(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'location', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByRegistered() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'registered');
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByStartDateAndTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'startDateAndTime');
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByTitle(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'title', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension EventModelQueryProperty
+    on QueryBuilder<EventModel, EventModel, QQueryProperty> {
+  QueryBuilder<EventModel, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<EventModel, List<String>, QQueryOperations>
+      attachmentsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'attachments');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> contactEmailProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'contactEmail');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> contactNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'contactName');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> descriptionProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'description');
+    });
+  }
+
+  QueryBuilder<EventModel, int, QQueryOperations> durationDaysProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'durationDays');
+    });
+  }
+
+  QueryBuilder<EventModel, DateTime?, QQueryOperations> endTimeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'endTime');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> eventIDProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'eventID');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> eventUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'eventUrl');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> imageUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'imageUrl');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> locationProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'location');
+    });
+  }
+
+  QueryBuilder<EventModel, bool, QQueryOperations> registeredProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'registered');
+    });
+  }
+
+  QueryBuilder<EventModel, DateTime, QQueryOperations>
+      startDateAndTimeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'startDateAndTime');
+    });
+  }
+
+  QueryBuilder<EventModel, String, QQueryOperations> titleProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'title');
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -150,7 +150,9 @@ class _MyHomePageState extends State<MyHomePage> {
               ],
             ),
           ),
-          body: const EventList(),
+          body: model.initiated
+              ? const EventList()
+              : const Center(child: CircularProgressIndicator()),
         );
       }),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -150,9 +150,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ],
             ),
           ),
-          body: model.initiated
-              ? const EventList()
-              : const Center(child: CircularProgressIndicator()),
+          body: const EventList()
         );
       }),
     );

--- a/lib/model/csv_event.dart
+++ b/lib/model/csv_event.dart
@@ -1,11 +1,21 @@
 class CSVEvent {
+  final String title;
+  final DateTime startTime;
+  final String place;
   final String eventID;
   final bool registered;
+  final String link;
 
-  CSVEvent({required this.eventID, required this.registered});
+  CSVEvent(
+      {required this.eventID,
+      required this.registered,
+      required this.title,
+      required this.startTime,
+      required this.place,
+      required this.link});
 
   @override
   String toString() {
-    return "{eventID: $eventID, registered: $registered}";
+    return "{eventID: $eventID, title: $title, registered: $registered}";
   }
 }

--- a/lib/model/csv_event.dart
+++ b/lib/model/csv_event.dart
@@ -1,0 +1,11 @@
+class CSVEvent {
+  final String eventID;
+  final bool registered;
+
+  CSVEvent({required this.eventID, required this.registered});
+
+  @override
+  String toString() {
+    return "{eventID: $eventID, registered: $registered}";
+  }
+}

--- a/lib/model/event.dart
+++ b/lib/model/event.dart
@@ -1,3 +1,5 @@
+import '../constants/strings.dart';
+
 class Event {
   final String eventID;
   final String title;
@@ -45,7 +47,7 @@ class Event {
       hasEndTime = true;
       endTime = timeInput.split('-')[1];
     }
-    String eventUrl = json['url'] + json['link'];
+    String eventUrl = (json['url'] ?? Strings.midaBaseURL) + json['link'];
     String imageURL = (json['bild'] as String).isEmpty
         ? ""
         : json['url'] + "/?download=" + json['bild'];

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -163,24 +163,21 @@ class EventDetailScreen extends StatelessWidget {
                       child: Column(children: [
                         eventItem(
                             context, 0, event, model.userRegisteredForEvent),
-                        Consumer<EventDetailViewModel>(
-                            builder: (_, viewModel, __) {
-                          return viewModel.userRegisteredForEvent
-                              ? const SizedBox(
-                                  width: double.infinity,
-                                  child: Card(
-                                      color: KjGColors.kjgGreen,
-                                      child: Padding(
-                                          padding:
-                                              EdgeInsets.symmetric(vertical: 8),
-                                          child: Center(
-                                              child: Text(
-                                            "Du bist angemeldet",
-                                            style: TextStyle(
-                                                fontWeight: FontWeight.bold),
-                                          )))))
-                              : const SizedBox();
-                        }),
+                        model.userRegisteredForEvent
+                            ? const SizedBox(
+                                width: double.infinity,
+                                child: Card(
+                                    color: KjGColors.kjgGreen,
+                                    child: Padding(
+                                        padding:
+                                            EdgeInsets.symmetric(vertical: 8),
+                                        child: Center(
+                                            child: Text(
+                                          "Du bist angemeldet",
+                                          style: TextStyle(
+                                              fontWeight: FontWeight.bold),
+                                        )))))
+                            : const SizedBox(),
                         event.description.isNotEmpty
                             ? Card(
                                 child: Html(
@@ -254,7 +251,7 @@ class EventDetailScreen extends StatelessWidget {
             ),
             floatingActionButton: FloatingActionButton.extended(
               heroTag: null,
-              label: const Text("Anmelden / Abmelden"),
+              label: Text(model.userRegisteredForEvent ? "Abmelden" : "Anmelden"),
               onPressed: () async {
                 final token = await SharedPref().getToken();
                 if (context.mounted) {
@@ -274,7 +271,7 @@ class EventDetailScreen extends StatelessWidget {
                             );
                           })
                       .whenComplete(
-                          () => model.isUserRegisteredForEvent(event.eventID));
+                          () => model.refreshUserRegisteredForEvent(event.eventID));
                 }
               },
             ));

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -11,6 +11,7 @@ import 'package:kjg_muf_app/ui/widgets/attachments_widgert.dart';
 import 'package:kjg_muf_app/ui/widgets/event_item.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 import 'package:kjg_muf_app/viewmodels/event.detail.viewmodel.dart';
+import 'package:kjg_muf_app/viewmodels/event.list.viewmodel.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:map_launcher/map_launcher.dart';
 import 'package:provider/provider.dart';
@@ -23,8 +24,10 @@ import 'fullscreen_image.dart';
 
 class EventDetailScreen extends StatelessWidget {
   final Event event;
+  final Map<String, bool> registeredMap;
 
-  EventDetailScreen({super.key, required this.event});
+  EventDetailScreen(
+      {super.key, required this.event, required this.registeredMap});
 
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
@@ -63,7 +66,10 @@ class EventDetailScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => EventDetailViewModel(event),
+      create: (_) => EventDetailViewModel(
+        event,
+        registeredMap,
+      ),
       child: Builder(builder: (context) {
         final model = Provider.of<EventDetailViewModel>(context, listen: true);
         return Scaffold(
@@ -141,7 +147,8 @@ class EventDetailScreen extends StatelessWidget {
                   Padding(
                       padding: const EdgeInsets.fromLTRB(4.0, 4.0, 4.0, 128.0),
                       child: Column(children: [
-                        eventItem(context, 0, event),
+                        eventItem(
+                            context, 0, event, model.userRegisteredForEvent),
                         Consumer<EventDetailViewModel>(
                             builder: (_, viewModel, __) {
                           return viewModel.userRegisteredForEvent

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -12,6 +12,7 @@ import 'package:kjg_muf_app/ui/widgets/event_item.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 import 'package:kjg_muf_app/viewmodels/event.detail.viewmodel.dart';
 import 'package:kjg_muf_app/viewmodels/event.list.viewmodel.dart';
+import 'package:kjg_muf_app/viewmodels/main.viewmodel.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:map_launcher/map_launcher.dart';
 import 'package:provider/provider.dart';
@@ -25,9 +26,13 @@ import 'fullscreen_image.dart';
 class EventDetailScreen extends StatelessWidget {
   final Event event;
   final Map<String, bool> registeredMap;
+  final bool offline;
 
   EventDetailScreen(
-      {super.key, required this.event, required this.registeredMap});
+      {super.key,
+      required this.event,
+      required this.registeredMap,
+      required this.offline});
 
   final emailController = TextEditingController();
   final passwordController = TextEditingController();
@@ -69,6 +74,7 @@ class EventDetailScreen extends StatelessWidget {
       create: (_) => EventDetailViewModel(
         event,
         registeredMap,
+        offline,
       ),
       child: Builder(builder: (context) {
         final model = Provider.of<EventDetailViewModel>(context, listen: true);
@@ -83,42 +89,50 @@ class EventDetailScreen extends StatelessWidget {
                   Stack(
                     children: [
                       Align(
-                        child: SizedBox(
-                          height: 200.0,
-                          child: model.geolocationState ==
-                                  GeolocationState.loaded
-                              ? FlutterMap(
-                                  options: MapOptions(
-                                      center: LatLng(model.location!.latitude,
-                                          model.location!.longitude),
-                                      zoom: 14.0,
-                                      interactiveFlags: InteractiveFlag.none),
-                                  children: [
-                                    TileLayer(
-                                        minZoom: 1,
-                                        maxZoom: 18,
-                                        backgroundColor: Colors.white,
-                                        urlTemplate:
-                                            'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                                        subdomains: const ['a', 'b', 'c']),
-                                    MarkerLayer(markers: [
-                                      Marker(
-                                          point: LatLng(
-                                              model.location!.latitude,
-                                              model.location!.longitude),
-                                          builder: (context) =>
-                                              const Icon(Icons.place))
-                                    ])
-                                  ],
-                                )
-                              : model.geolocationState ==
-                                      GeolocationState.loading
-                                  ? const Center(
-                                      child: CircularProgressIndicator())
-                                  : const Center(
-                                      child: Text(
-                                          "Es konnte kein Ort gefunden werden")),
-                        ),
+                        child: event.location == ""
+                            ? Container()
+                            : SizedBox(
+                                height: 200.0,
+                                child: model.geolocationState ==
+                                        GeolocationState.loaded
+                                    ? FlutterMap(
+                                        options: MapOptions(
+                                            center: LatLng(
+                                                model.location!.latitude,
+                                                model.location!.longitude),
+                                            zoom: 14.0,
+                                            interactiveFlags:
+                                                InteractiveFlag.none),
+                                        children: [
+                                          TileLayer(
+                                              minZoom: 1,
+                                              maxZoom: 18,
+                                              backgroundColor: Colors.white,
+                                              urlTemplate:
+                                                  'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                                              subdomains: const [
+                                                'a',
+                                                'b',
+                                                'c'
+                                              ]),
+                                          MarkerLayer(markers: [
+                                            Marker(
+                                                point: LatLng(
+                                                    model.location!.latitude,
+                                                    model.location!.longitude),
+                                                builder: (context) =>
+                                                    const Icon(Icons.place))
+                                          ])
+                                        ],
+                                      )
+                                    : model.geolocationState ==
+                                            GeolocationState.loading
+                                        ? const Center(
+                                            child: CircularProgressIndicator())
+                                        : const Center(
+                                            child: Text(
+                                                "Es konnte kein Ort gefunden werden")),
+                              ),
                       ),
                       if (model.location != null)
                         Positioned.fill(

--- a/lib/ui/screens/event_list.dart
+++ b/lib/ui/screens/event_list.dart
@@ -21,8 +21,23 @@ class EventList extends StatelessWidget {
                 effect: const ShimmerEffect(),
                 enabled: model.events == null,
                 child: ListView.builder(
-                    itemCount: events.length,
+                    itemCount: events.length + 1,
                     itemBuilder: (BuildContext context, int index) {
+                      if (index == 0) {
+                        return Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            const Text("Nur angemeldete Veranstaltungen"),
+                            Switch(
+                              onChanged: (value) {
+                                model.setOnlyRegistered(value);
+                              },
+                              value: model.onlyRegistered,
+                            )
+                          ],
+                        );
+                      }
+                      index -= 1;
                       return InkWell(
                           child: eventItem(
                               context,

--- a/lib/ui/screens/event_list.dart
+++ b/lib/ui/screens/event_list.dart
@@ -24,11 +24,19 @@ class EventList extends StatelessWidget {
                     itemCount: events.length,
                     itemBuilder: (BuildContext context, int index) {
                       return InkWell(
-                          child: eventItem(context, index, events[index]),
-                          onTap: () => Navigator.of(context).push(
-                              MaterialPageRoute(
-                                  builder: (context) => EventDetailScreen(
-                                      event: events[index]))));
+                          child: eventItem(
+                              context,
+                              index,
+                              events[index],
+                              model.registeredMap?[events[index].eventID] ??
+                                  false),
+                          onTap: () => Navigator.of(context)
+                              .push(MaterialPageRoute(
+                                builder: (context) => EventDetailScreen(
+                                    event: events[index],
+                                    registeredMap: model.registeredMap ?? {}),
+                              ))
+                              .then((value) => model.refresh()));
                     }),
               ));
         }));

--- a/lib/ui/screens/event_list.dart
+++ b/lib/ui/screens/event_list.dart
@@ -3,6 +3,7 @@ import 'package:kjg_muf_app/model/event.dart';
 import 'package:kjg_muf_app/ui/screens/event_detail_screen.dart';
 import 'package:kjg_muf_app/ui/widgets/event_item.dart';
 import 'package:kjg_muf_app/viewmodels/event.list.viewmodel.dart';
+import 'package:kjg_muf_app/viewmodels/main.viewmodel.dart';
 import 'package:provider/provider.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
@@ -12,11 +13,15 @@ class EventList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-        create: (_) => EventListViewModel(),
-        child: Consumer<EventListViewModel>(builder: (_, model, __) {
+      create: (_) => EventListViewModel(),
+      builder: (context, child) {
+        bool loggedIn = Provider.of<MainViewModel>(context).isLoggedIn;
+        Provider.of<EventListViewModel>(context, listen: false)
+            .loadEvents(loggedIn);
+        return Consumer<EventListViewModel>(builder: (_, model, __) {
           final events = model.events ?? Event.createFakeData();
           return RefreshIndicator(
-              onRefresh: model.loadEvents,
+              onRefresh: () => model.loadEvents(loggedIn),
               child: Skeletonizer(
                 effect: const ShimmerEffect(),
                 enabled: model.events == null,
@@ -54,6 +59,8 @@ class EventList extends StatelessWidget {
                               .then((value) => model.refresh()));
                     }),
               ));
-        }));
+        });
+      },
+    );
   }
 }

--- a/lib/ui/screens/event_list.dart
+++ b/lib/ui/screens/event_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kjg_muf_app/constants/kjg_colors.dart';
 import 'package:kjg_muf_app/model/event.dart';
 import 'package:kjg_muf_app/ui/screens/event_detail_screen.dart';
 import 'package:kjg_muf_app/ui/widgets/event_item.dart';
@@ -15,13 +16,24 @@ class EventList extends StatelessWidget {
     return ChangeNotifierProvider(
       create: (_) => EventListViewModel(),
       builder: (context, child) {
-        bool loggedIn = Provider.of<MainViewModel>(context).isLoggedIn;
-        Provider.of<EventListViewModel>(context, listen: false)
-            .loadEvents(loggedIn);
+        MainViewModel mainViewModel = Provider.of<MainViewModel>(context);
+        bool loggedIn = mainViewModel.isLoggedIn;
+        bool offline = mainViewModel.offline;
+        if (mainViewModel.initiated && !offline) {
+          Provider.of<EventListViewModel>(context, listen: false)
+              .loadEvents(loggedIn);
+        }
         return Consumer<EventListViewModel>(builder: (_, model, __) {
           final events = model.events ?? Event.createFakeData();
           return RefreshIndicator(
-              onRefresh: () => model.loadEvents(loggedIn),
+              onRefresh: () {
+                if (!offline) {
+                  return model.loadEvents(loggedIn);
+                } else {
+                  _showSnackBar(context);
+                  return Future.value();
+                }
+              },
               child: Skeletonizer(
                 effect: const ShimmerEffect(),
                 enabled: model.events == null,
@@ -30,15 +42,30 @@ class EventList extends StatelessWidget {
                     itemBuilder: (BuildContext context, int index) {
                       if (index == 0) {
                         return Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            const Text("Nur angemeldete Veranstaltungen"),
-                            Switch(
-                              onChanged: (value) {
-                                model.setOnlyRegistered(value);
-                              },
-                              value: model.onlyRegistered,
-                            )
+                            offline
+                                ? Padding(
+                                    padding: const EdgeInsets.only(left: 8.0),
+                                    child: InkWell(
+                                      onTap: () => _showSnackBar(context),
+                                      child: const Text("Offlinemodus",
+                                          style: TextStyle(color: Colors.red)),
+                                    ),
+                                  )
+                                : Container(),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: [
+                                const Text("Nur angemeldete Veranstaltungen"),
+                                Switch(
+                                  onChanged: (value) {
+                                    model.setOnlyRegistered(value);
+                                  },
+                                  value: model.onlyRegistered,
+                                )
+                              ],
+                            ),
                           ],
                         );
                       }
@@ -54,7 +81,8 @@ class EventList extends StatelessWidget {
                               .push(MaterialPageRoute(
                                 builder: (context) => EventDetailScreen(
                                     event: events[index],
-                                    registeredMap: model.registeredMap ?? {}),
+                                    registeredMap: model.registeredMap ?? {},
+                                    offline: offline),
                               ))
                               .then((value) => model.refresh()));
                     }),
@@ -62,5 +90,16 @@ class EventList extends StatelessWidget {
         });
       },
     );
+  }
+
+  _showSnackBar(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        action: SnackBarAction(
+          onPressed: Provider.of<MainViewModel>(context, listen: false).init,
+          label: "Geh Online",
+          backgroundColor: KjGColors.kjgDarkBlue,
+          textColor: KjGColors.kjgWhite,
+        ),
+        content: const Text("Im Offlinemodus")));
   }
 }

--- a/lib/ui/widgets/event_item.dart
+++ b/lib/ui/widgets/event_item.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:kjg_muf_app/model/event.dart';
 
+import '../../constants/kjg_colors.dart';
+
 DateFormat dateFormat = DateFormat("dd.MM.yyyy");
 DateFormat timeFormat = DateFormat("HH:mm");
 
-Widget eventItem(BuildContext context, int index, Event event) {
+Widget eventItem(
+    BuildContext context, int index, Event event, bool registered) {
   return Card(
+    color: registered ? KjGColors.kjgGreen : null,
     child: Padding(
       padding: const EdgeInsets.all(8.0),
       child: Column(

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -1,0 +1,49 @@
+import 'package:csv/csv.dart';
+
+import '../model/csv_event.dart';
+
+class CSVHelper {
+  static List<CSVEvent> csvToEvents(String csvString) {
+    // csv format: [Datum, Bild, Veranstaltung, Verein, , , Ort, Status, Link]
+    List<List<dynamic>> rowsAsListOfValues =
+        const CsvToListConverter().convert(csvString, fieldDelimiter: ";");
+
+    int idIndex = -1;
+    int statusIndex = -1;
+    int placeIndex = -1;
+    List<dynamic> firstRow = rowsAsListOfValues[0];
+    for (int i = 0; i < firstRow.length; i++) {
+      if (firstRow[i] == "Link") {
+        idIndex = i;
+      } else if (firstRow[i] == "Status") {
+        statusIndex = i;
+      } else if (firstRow[i] == "Ort") {
+        placeIndex = i;
+      }
+    }
+    // something went wrong (wrong token?)
+    if (placeIndex == -1 || idIndex == -1 || statusIndex == -1) {
+      throw Exception("Error getting personal events");
+    }
+
+    List<CSVEvent> csvEvents = [];
+    for (List<dynamic> row in rowsAsListOfValues) {
+      // e.g. https://mida.kjg.de/DVMuenchenundFreising_METrudering/?veranstaltung=6226@876 (@ doesn't always exist)
+      String link = row[idIndex];
+      int a = link.indexOf("veranstaltung=");
+      int b = link.indexOf("@");
+      if (a != -1) {
+        String id = link.substring(a + 14, b == -1 ? link.length : b);
+
+        csvEvents.add(
+          CSVEvent(
+            eventID: id,
+            registered: row[statusIndex] == "angemeldet",
+          ),
+        );
+      }
+    }
+
+    return csvEvents;
+  }
+}

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -2,6 +2,7 @@ import 'package:csv/csv.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
 
+import '../constants/strings.dart';
 import '../model/csv_event.dart';
 
 class CSVHelper {
@@ -10,41 +11,43 @@ class CSVHelper {
     List<List<dynamic>> rowsAsListOfValues =
         const CsvToListConverter().convert(csvString, fieldDelimiter: ";");
 
-    int idIndex = -1;
+    int linkIndex = -1;
     int statusIndex = -1;
     int placeIndex = -1;
     int dateIndex = -1;
     int titleIndex = -1;
     List<dynamic> firstRow = rowsAsListOfValues[0];
     for (int i = 0; i < firstRow.length; i++) {
-      if (firstRow[i] == "Link") {
-        idIndex = i;
-      } else if (firstRow[i] == "Status") {
+      if (firstRow[i] == Strings.midaCsvLinkHeader) {
+        linkIndex = i;
+      } else if (firstRow[i] == Strings.midaCsvStatusHeader) {
         statusIndex = i;
-      } else if (firstRow[i] == "Ort") {
+      } else if (firstRow[i] == Strings.midaCsvPlaceHeader) {
         placeIndex = i;
-      } else if (firstRow[i] == "Veranstaltung") {
+      } else if (firstRow[i] == Strings.midaCsvTitleHeader) {
         titleIndex = i;
-      } else if (firstRow[i] == "Datum") {
+      } else if (firstRow[i] == Strings.midaCsvDateHeader) {
         dateIndex = i;
       }
     }
     // something went wrong (wrong token?)
     if (placeIndex == -1 ||
-        idIndex == -1 ||
+        linkIndex == -1 ||
         statusIndex == -1 ||
-        dateIndex == -1) {
+        dateIndex == -1 ||
+        titleIndex == -1) {
       return [];
     }
 
     List<CSVEvent> csvEvents = [];
     for (List<dynamic> row in rowsAsListOfValues) {
       // e.g. https://mida.kjg.de/DVMuenchenundFreising_METrudering/?veranstaltung=6226@876 (@ doesn't always exist)
-      String link = row[idIndex];
-      int a = link.indexOf("veranstaltung=");
-      int b = link.indexOf("@");
-      if (a != -1) {
-        String id = link.substring(a + 14, b == -1 ? link.length : b);
+      String link = row[linkIndex];
+      int idStart = link.indexOf("veranstaltung=");
+      int idEnd = link.indexOf("@");
+      if (idStart != -1) {
+        String id =
+            link.substring(idStart + 14, idEnd == -1 ? link.length : idEnd);
 
         String date = (row[dateIndex] as String).substring(3);
 
@@ -70,7 +73,7 @@ class CSVHelper {
             title: row[titleIndex],
             startTime: d,
             place: row[placeIndex],
-            link: row[idIndex],
+            link: row[linkIndex],
           ),
         );
       }

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -16,7 +16,6 @@ class CSVHelper {
     int dateIndex = -1;
     int titleIndex = -1;
     List<dynamic> firstRow = rowsAsListOfValues[0];
-    debugPrint(firstRow.toString());
     for (int i = 0; i < firstRow.length; i++) {
       if (firstRow[i] == "Link") {
         idIndex = i;
@@ -64,12 +63,10 @@ class CSVHelper {
           }
         }
 
-        debugPrint("EventID: $id, Status: ${row[statusIndex]}");
-
         csvEvents.add(
           CSVEvent(
             eventID: id,
-            registered: row[statusIndex] == "angemeldet",
+            registered: (row[statusIndex] as String).contains("angemeldet"),
             title: row[titleIndex],
             startTime: d,
             place: row[placeIndex],

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -34,7 +34,7 @@ class CSVHelper {
         idIndex == -1 ||
         statusIndex == -1 ||
         dateIndex == -1) {
-      throw Exception("Error getting personal events");
+      return [];
     }
 
     List<CSVEvent> csvEvents = [];

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -64,6 +64,8 @@ class CSVHelper {
           }
         }
 
+        debugPrint("EventID: $id, Status: ${row[statusIndex]}");
+
         csvEvents.add(
           CSVEvent(
             eventID: id,

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -1,4 +1,6 @@
 import 'package:csv/csv.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:intl/intl.dart';
 
 import '../model/csv_event.dart';
 
@@ -11,7 +13,10 @@ class CSVHelper {
     int idIndex = -1;
     int statusIndex = -1;
     int placeIndex = -1;
+    int dateIndex = -1;
+    int titleIndex = -1;
     List<dynamic> firstRow = rowsAsListOfValues[0];
+    debugPrint(firstRow.toString());
     for (int i = 0; i < firstRow.length; i++) {
       if (firstRow[i] == "Link") {
         idIndex = i;
@@ -19,10 +24,17 @@ class CSVHelper {
         statusIndex = i;
       } else if (firstRow[i] == "Ort") {
         placeIndex = i;
+      } else if (firstRow[i] == "Veranstaltung") {
+        titleIndex = i;
+      } else if (firstRow[i] == "Datum") {
+        dateIndex = i;
       }
     }
     // something went wrong (wrong token?)
-    if (placeIndex == -1 || idIndex == -1 || statusIndex == -1) {
+    if (placeIndex == -1 ||
+        idIndex == -1 ||
+        statusIndex == -1 ||
+        dateIndex == -1) {
       throw Exception("Error getting personal events");
     }
 
@@ -35,10 +47,31 @@ class CSVHelper {
       if (a != -1) {
         String id = link.substring(a + 14, b == -1 ? link.length : b);
 
+        String date = (row[dateIndex] as String).substring(3);
+
+        int dashIndex = date.indexOf("-");
+        DateTime d;
+        if (dashIndex == -1) {
+          d = DateFormat("dd.MM.yy, HH:mm").parse(date);
+        } else {
+          date = date.substring(0, dashIndex);
+          if (date.length == 15) {
+            d = DateFormat("dd.MM.yy, HH:mm").parse(date);
+          } else if (date.length == 8) {
+            d = DateFormat("dd.MM.yy").parse(date);
+          } else {
+            d = DateTime.now();
+          }
+        }
+
         csvEvents.add(
           CSVEvent(
             eventID: id,
             registered: row[statusIndex] == "angemeldet",
+            title: row[titleIndex],
+            startTime: d,
+            place: row[placeIndex],
+            link: row[idIndex],
           ),
         );
       }

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:kjg_muf_app/backend/mida_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SharedPref {
@@ -13,8 +14,8 @@ class SharedPref {
   static const keyName = "key.full.name";
   static const keyUserName = "key.user.name";
   static const keyPasswordHash = "key.password.hash";
+  static const keyPassword = "key.password";
   static const keyUserID = "key.user.id";
-  static const keyUserCookie = "key.user.cookie";
 
   Future<void> saveName(String fullName) async {
     var prefs = await SharedPreferences.getInstance();
@@ -46,6 +47,16 @@ class SharedPref {
     return prefs.getString(keyPasswordHash);
   }
 
+  Future<void> savePassword(String password) async {
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setString(keyPassword, password);
+  }
+
+  Future<String?> getPassword() async {
+    var prefs = await SharedPreferences.getInstance();
+    return prefs.getString(keyPassword);
+  }
+
   Future<void> saveUserID(int userID) async {
     var prefs = await SharedPreferences.getInstance();
     await prefs.setInt(keyUserID, userID);
@@ -54,16 +65,6 @@ class SharedPref {
   Future<int?> getUserID() async {
     var prefs = await SharedPreferences.getInstance();
     return prefs.getInt(keyUserID);
-  }
-
-  Future<void> saveUserCookie(String cookie) async {
-    var prefs = await SharedPreferences.getInstance();
-    await prefs.setString(keyUserCookie, cookie);
-  }
-
-  Future<String?> getUserCookie() async {
-    var prefs = await SharedPreferences.getInstance();
-    return prefs.getString(keyUserCookie);
   }
 
   Future<String?> getToken() async {
@@ -82,7 +83,9 @@ class SharedPref {
     await prefs.remove(keyUserName);
     await prefs.remove(keyPasswordHash);
     await prefs.remove(keyUserID);
+    await prefs.remove(keyPassword);
     CookieManager cookieManager = CookieManager.instance();
+    MidaService().deleteAllCookies();
     await cookieManager.deleteAllCookies();
   }
 }

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -14,6 +14,7 @@ class SharedPref {
   static const keyUserName = "key.user.name";
   static const keyPasswordHash = "key.password.hash";
   static const keyUserID = "key.user.id";
+  static const keyUserCookie = "key.user.cookie";
 
   Future<void> saveName(String fullName) async {
     var prefs = await SharedPreferences.getInstance();
@@ -53,6 +54,16 @@ class SharedPref {
   Future<int?> getUserID() async {
     var prefs = await SharedPreferences.getInstance();
     return prefs.getInt(keyUserID);
+  }
+
+  Future<void> saveUserCookie(String cookie) async {
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setString(keyUserCookie, cookie);
+  }
+
+  Future<String?> getUserCookie() async {
+    var prefs = await SharedPreferences.getInstance();
+    return prefs.getString(keyUserCookie);
   }
 
   Future<String?> getToken() async {

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:kjg_muf_app/backend/mida_service.dart';
+import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/event.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -10,16 +11,20 @@ enum GeolocationState { loaded, loading, error }
 class EventDetailViewModel extends ChangeNotifier {
   double? latitudeCache;
   double? longitudeCache;
-  bool _userRegisteredForEvent = false;
-  bool get userRegisteredForEvent => _userRegisteredForEvent;
+
+  bool get userRegisteredForEvent => registeredMap[event.eventID] ?? false;
+  final Map<String, bool> registeredMap;
+  final Event event;
 
   Location? _location;
+
   Location? get location => _location;
 
   GeolocationState _geolocationState = GeolocationState.loading;
+
   GeolocationState get geolocationState => _geolocationState;
 
-  EventDetailViewModel(Event event) {
+  EventDetailViewModel(this.event, this.registeredMap) {
     getLocationFromAddress(event);
     isUserRegisteredForEvent(event.eventID);
   }
@@ -54,16 +59,21 @@ class EventDetailViewModel extends ChangeNotifier {
       return;
     }
 
-    var registrations = await MidaService().getRegistrationsForEvent(eventID);
-    var userID = await SharedPref().getUserID();
+    // get events starting from event date for a week (less not possible)
+    List<CSVEvent> events =
+        await MidaService().getWeekEventsPersonal(event.startDateAndTime);
+    debugPrint(events.toString());
 
-    bool isUserRegisteredForEvent = registrations
-        .where((element) =>
-            element.userID == userID.toString() && element.status == 0)
-        .isNotEmpty;
+    bool isUserRegisteredForEvent = false;
+    for (CSVEvent e in events) {
+      if (e.eventID == eventID) {
+        isUserRegisteredForEvent = e.registered;
+        break;
+      }
+    }
 
-    if (_userRegisteredForEvent != isUserRegisteredForEvent) {
-      _userRegisteredForEvent = isUserRegisteredForEvent;
+    if (userRegisteredForEvent != isUserRegisteredForEvent) {
+      registeredMap[eventID] = isUserRegisteredForEvent;
       notifyListeners();
     }
   }

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -27,7 +27,7 @@ class EventDetailViewModel extends ChangeNotifier {
 
   EventDetailViewModel(this.event, this.registeredMap, this.offline) {
     getLocationFromAddress(event);
-    isUserRegisteredForEvent(event.eventID);
+    refreshUserRegisteredForEvent(event.eventID);
   }
 
   getLocationFromAddress(Event event) async {
@@ -55,7 +55,7 @@ class EventDetailViewModel extends ChangeNotifier {
     longitudeCache = longitude;
   }
 
-  Future<void> isUserRegisteredForEvent(String eventID) async {
+  Future<void> refreshUserRegisteredForEvent(String eventID) async {
     if (offline) return;
     if (await SharedPref().getToken() == null) {
       return;

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -62,7 +62,6 @@ class EventDetailViewModel extends ChangeNotifier {
     // get events starting from event date for a week (less not possible)
     List<CSVEvent> events =
         await MidaService().getWeekEventsPersonal(event.startDateAndTime);
-    debugPrint(events.toString());
 
     bool isUserRegisteredForEvent = false;
     for (CSVEvent e in events) {

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -63,7 +63,7 @@ class EventDetailViewModel extends ChangeNotifier {
 
     // get events starting from event date for a week (less not possible)
     List<CSVEvent> events =
-        await MidaService().getWeekEventsPersonal(event.startDateAndTime);
+        await MidaService().getFutureEventsPersonal(weekStartingFrom: event.startDateAndTime);
 
     bool isUserRegisteredForEvent = false;
     for (CSVEvent e in events) {

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -15,6 +15,7 @@ class EventDetailViewModel extends ChangeNotifier {
   bool get userRegisteredForEvent => registeredMap[event.eventID] ?? false;
   final Map<String, bool> registeredMap;
   final Event event;
+  final bool offline;
 
   Location? _location;
 
@@ -24,7 +25,7 @@ class EventDetailViewModel extends ChangeNotifier {
 
   GeolocationState get geolocationState => _geolocationState;
 
-  EventDetailViewModel(this.event, this.registeredMap) {
+  EventDetailViewModel(this.event, this.registeredMap, this.offline) {
     getLocationFromAddress(event);
     isUserRegisteredForEvent(event.eventID);
   }
@@ -55,6 +56,7 @@ class EventDetailViewModel extends ChangeNotifier {
   }
 
   Future<void> isUserRegisteredForEvent(String eventID) async {
+    if (offline) return;
     if (await SharedPref().getToken() == null) {
       return;
     }

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -45,7 +45,6 @@ class EventListViewModel extends ChangeNotifier {
   }
 
   Future<void> loadEvents(bool loggedIn) async {
-    debugPrint("loadEvents $loggedIn");
     _events = await MidaService().getEvents();
 
     if (_events != null && loggedIn) {

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -27,6 +27,9 @@ class EventListViewModel extends ChangeNotifier {
     if (_events != null) {
       List<Event> eNN = _events!;
       var list = await MidaService().getFutureEventsPersonal();
+      for(CSVEvent e in list) {
+        debugPrint(e.toString());
+      }
 
       // find personal events
       List<String> eventIDs = list.map((e) => e.eventID).toList();
@@ -34,16 +37,36 @@ class EventListViewModel extends ChangeNotifier {
         eventIDs.remove(e.eventID);
       }
 
+      List<String> publicEventIDs = eNN.map((e) => e.eventID).toList();
+      bool inserted = false;
+
       // add personal events to list and sort
-      for (String s in eventIDs) {
-        try {
-          // getEvent sometimes empty... catch while investigating
-          eNN.add(await MidaService().getEvent(s));
-        } catch (e) {
-          debugPrint("Error getting event $s");
+      for (CSVEvent event in list) {
+        if (!publicEventIDs.contains(event.eventID)) {
+          try {
+            // getEvent sometimes empty... catch while investigating
+            eNN.add(await MidaService().getEvent(event.eventID));
+          } catch (e) {
+            Event ev = Event(
+              title: event.title,
+              description: "<b>Genaue Daten nicht in App verfügbar<br>Bitte über MiDa Knopf anschauen</b>",
+              imageUrl: "",
+              location: event.place,
+              attachments: [],
+              contactEmail: "",
+              contactName: "",
+              durationDays: 0,
+              eventID: event.eventID,
+              eventUrl: event.link,
+              startDateAndTime: event.startTime,
+              endTime: event.startTime,
+            );
+            eNN.add(ev);
+          }
+          inserted = true;
         }
       }
-      if (eventIDs.isNotEmpty) {
+      if (inserted) {
         eNN.sort(
           (a, b) => a.startDateAndTime.compareTo(b.startDateAndTime),
         );

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -23,17 +23,17 @@ class EventListViewModel extends ChangeNotifier {
   }
 
   EventListViewModel() {
-    loadEvents();
   }
 
   bool registeredForEvent(String eventID) {
     return registeredMap?[eventID] ?? false;
   }
 
-  Future<void> loadEvents() async {
+  Future<void> loadEvents(bool loggedIn) async {
+    debugPrint("loadEvents $loggedIn");
     _events = await MidaService().getEvents();
 
-    if (_events != null) {
+    if (_events != null && loggedIn) {
       List<Event> eNN = _events!;
       var list = await MidaService().getFutureEventsPersonal();
 
@@ -82,6 +82,8 @@ class EventListViewModel extends ChangeNotifier {
         registeredMap[e.eventID] = e.registered;
       }
       _registeredMap = registeredMap;
+    }else {
+      _registeredMap = {};
     }
 
     notifyListeners();

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -38,6 +38,7 @@ class EventListViewModel extends ChangeNotifier {
       _events?.add(eM.toEvent());
       _registeredMap?[eM.eventID] = eM.registered;
     }
+    notifyListeners();
   }
 
   bool registeredForEvent(String eventID) {

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -4,6 +4,8 @@ import 'package:kjg_muf_app/database/db_service.dart';
 import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/event.dart';
 
+import '../database/model/event_model.dart';
+
 class EventListViewModel extends ChangeNotifier {
   List<Event>? _events;
   Map<String, bool>? _registeredMap;
@@ -28,7 +30,14 @@ class EventListViewModel extends ChangeNotifier {
   }
 
   Future<void> _loadCachedEvents() async {
-    _events = await DBService().getCachedEvents();
+    List<EventModel> eventModels = await DBService().getCachedEvents();
+
+    _events = [];
+    _registeredMap = {};
+    for (EventModel eM in eventModels) {
+      _events?.add(eM.toEvent());
+      _registeredMap?[eM.eventID] = eM.registered;
+    }
   }
 
   bool registeredForEvent(String eventID) {
@@ -91,6 +100,8 @@ class EventListViewModel extends ChangeNotifier {
     } else {
       _registeredMap = {};
     }
+
+    DBService().cacheEvents(_events ?? [], _registeredMap ?? {});
 
     notifyListeners();
   }

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -3,15 +3,24 @@ import 'package:kjg_muf_app/backend/mida_service.dart';
 import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/event.dart';
 
-import '../utils/shared_prefs.dart';
-
 class EventListViewModel extends ChangeNotifier {
   List<Event>? _events;
   Map<String, bool>? _registeredMap;
 
-  List<Event>? get events => _events;
+  List<Event>? get events => onlyRegistered
+      ? _events
+          ?.where((element) => registeredMap?[element.eventID] ?? false)
+          .toList()
+      : _events;
 
   Map<String, bool>? get registeredMap => _registeredMap;
+
+  bool onlyRegistered = false;
+
+  void setOnlyRegistered(bool newValue) {
+    onlyRegistered = newValue;
+    notifyListeners();
+  }
 
   EventListViewModel() {
     loadEvents();

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/backend/mida_service.dart';
+import 'package:kjg_muf_app/database/db_service.dart';
 import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/event.dart';
 
@@ -23,6 +24,11 @@ class EventListViewModel extends ChangeNotifier {
   }
 
   EventListViewModel() {
+    _loadCachedEvents();
+  }
+
+  Future<void> _loadCachedEvents() async {
+    _events = await DBService().getCachedEvents();
   }
 
   bool registeredForEvent(String eventID) {
@@ -82,7 +88,7 @@ class EventListViewModel extends ChangeNotifier {
         registeredMap[e.eventID] = e.registered;
       }
       _registeredMap = registeredMap;
-    }else {
+    } else {
       _registeredMap = {};
     }
 

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -27,15 +27,6 @@ class EventListViewModel extends ChangeNotifier {
     if (_events != null) {
       List<Event> eNN = _events!;
       var list = await MidaService().getFutureEventsPersonal();
-      for(CSVEvent e in list) {
-        debugPrint(e.toString());
-      }
-
-      // find personal events
-      List<String> eventIDs = list.map((e) => e.eventID).toList();
-      for (Event e in eNN) {
-        eventIDs.remove(e.eventID);
-      }
 
       List<String> publicEventIDs = eNN.map((e) => e.eventID).toList();
       bool inserted = false;
@@ -47,9 +38,12 @@ class EventListViewModel extends ChangeNotifier {
             // getEvent sometimes empty... catch while investigating
             eNN.add(await MidaService().getEvent(event.eventID));
           } catch (e) {
+            // display event with basic information instead
+            // WebView will have full information
             Event ev = Event(
               title: event.title,
-              description: "<b>Genaue Daten nicht in App verfügbar<br>Bitte über MiDa Knopf anschauen</b>",
+              description:
+                  "<b>Genaue Daten zur Veranstaltung sind nicht in der App verfügbar.<br>Bitte über den MiDa Knopf anschauen.</b>",
               imageUrl: "",
               location: event.place,
               attachments: [],
@@ -66,6 +60,7 @@ class EventListViewModel extends ChangeNotifier {
           inserted = true;
         }
       }
+
       if (inserted) {
         eNN.sort(
           (a, b) => a.startDateAndTime.compareTo(b.startDateAndTime),

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -1,17 +1,61 @@
 import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/backend/mida_service.dart';
+import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/event.dart';
+
+import '../utils/shared_prefs.dart';
 
 class EventListViewModel extends ChangeNotifier {
   List<Event>? _events;
+  Map<String, bool>? _registeredMap;
+
   List<Event>? get events => _events;
+
+  Map<String, bool>? get registeredMap => _registeredMap;
 
   EventListViewModel() {
     loadEvents();
   }
 
+  bool registeredForEvent(String eventID) {
+    return registeredMap?[eventID] ?? false;
+  }
+
   Future<void> loadEvents() async {
     _events = await MidaService().getEvents();
+
+    if (_events != null) {
+      List<Event> eNN = _events!;
+      var list = await MidaService().getFutureEventsPersonal();
+
+      // find personal events
+      List<String> eventIDs = list.map((e) => e.eventID).toList();
+      for (Event e in eNN) {
+        eventIDs.remove(e.eventID);
+      }
+
+      // add personal events to list and sort
+      for (String s in eventIDs) {
+        eNN.add(await MidaService().getEvent(s));
+      }
+      if (eventIDs.isNotEmpty) {
+        eNN.sort(
+          (a, b) => a.startDateAndTime.compareTo(b.startDateAndTime),
+        );
+      }
+
+      // create map eventID -> registered
+      Map<String, bool> registeredMap = {};
+      for (CSVEvent e in list) {
+        registeredMap[e.eventID] = e.registered;
+      }
+      _registeredMap = registeredMap;
+    }
+
+    notifyListeners();
+  }
+
+  void refresh() {
     notifyListeners();
   }
 }

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -36,7 +36,12 @@ class EventListViewModel extends ChangeNotifier {
 
       // add personal events to list and sort
       for (String s in eventIDs) {
-        eNN.add(await MidaService().getEvent(s));
+        try {
+          // getEvent sometimes empty... catch while investigating
+          eNN.add(await MidaService().getEvent(s));
+        } catch (e) {
+          debugPrint("Error getting event $s");
+        }
       }
       if (eventIDs.isNotEmpty) {
         eNN.sort(

--- a/lib/viewmodels/main.viewmodel.dart
+++ b/lib/viewmodels/main.viewmodel.dart
@@ -22,8 +22,12 @@ class MainViewModel extends ChangeNotifier {
 
   bool get initiated => _initiated;
 
+  bool _offline = false;
+
+  bool get offline => _offline;
+
   MainViewModel() {
-    _init();
+    init();
   }
 
   setLoading(bool loading) async {
@@ -31,14 +35,21 @@ class MainViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _init() async {
+  Future<void> init() async {
     _nameCache = await SharedPref().getName();
     _userNameCache = await SharedPref().getUserName();
     String? password = await SharedPref().getPassword();
 
     if (_userNameCache != null && password != null) {
-      bool loggedIn =
-          await MidaService().verifyLoginForUserName(_userNameCache!, password);
+      bool loggedIn;
+      try {
+        loggedIn = await MidaService()
+            .verifyLoginForUserName(_userNameCache!, password);
+        _offline = false;
+      } catch (e) {
+        loggedIn = _nameCache != null;
+        _offline = true;
+      }
       _initiated = true;
       if (!loggedIn) {
         logoutUser();

--- a/lib/viewmodels/main.viewmodel.dart
+++ b/lib/viewmodels/main.viewmodel.dart
@@ -5,22 +5,49 @@ import 'package:url_launcher/url_launcher.dart';
 
 class MainViewModel extends ChangeNotifier {
   bool _loading = false;
+
   bool get loading => _loading;
 
   bool get isLoggedIn => nameCache != null;
 
   String? _nameCache;
+
   String? get nameCache => _nameCache;
 
   String? _userNameCache;
+
   String? get userNameCache => _userNameCache;
 
+  bool _initiated = false;
+
+  bool get initiated => _initiated;
+
   MainViewModel() {
-    loadUserName();
+    _init();
   }
 
   setLoading(bool loading) async {
     _loading = loading;
+    notifyListeners();
+  }
+
+  Future<void> _init() async {
+    _nameCache = await SharedPref().getName();
+    _userNameCache = await SharedPref().getUserName();
+    String? password = await SharedPref().getPassword();
+
+    debugPrint("Init $userNameCache $password");
+    if (_userNameCache != null && password != null) {
+      bool loggedIn =
+          await MidaService().verifyLoginForUserName(_userNameCache!, password);
+      _initiated = true;
+      if (!loggedIn) {
+        logoutUser();
+      } else {
+        notifyListeners();
+      }
+    }
+    _initiated = true;
     notifyListeners();
   }
 

--- a/lib/viewmodels/main.viewmodel.dart
+++ b/lib/viewmodels/main.viewmodel.dart
@@ -40,7 +40,10 @@ class MainViewModel extends ChangeNotifier {
     _userNameCache = await SharedPref().getUserName();
     String? password = await SharedPref().getPassword();
 
-    if (_userNameCache != null && password != null) {
+    if (userNameCache != null && password == null) {
+      // users of older version of the app need to log in again
+      logoutUser();
+    } else if (_userNameCache != null && password != null) {
       bool loggedIn;
       try {
         loggedIn = await MidaService()

--- a/lib/viewmodels/main.viewmodel.dart
+++ b/lib/viewmodels/main.viewmodel.dart
@@ -36,7 +36,6 @@ class MainViewModel extends ChangeNotifier {
     _userNameCache = await SharedPref().getUserName();
     String? password = await SharedPref().getPassword();
 
-    debugPrint("Init $userNameCache $password");
     if (_userNameCache != null && password != null) {
       bool loggedIn =
           await MidaService().verifyLoginForUserName(_userNameCache!, password);
@@ -46,9 +45,10 @@ class MainViewModel extends ChangeNotifier {
       } else {
         notifyListeners();
       }
+    } else {
+      _initiated = true;
+      notifyListeners();
     }
-    _initiated = true;
-    notifyListeners();
   }
 
   Future<void> loadUserName() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   add_2_calendar: ^2.2.5
   html: ^0.15.4
   photo_view: ^0.14.0
+  csv: ^5.1.1
 
 dev_dependencies:
   flutter_launcher_icons: "^0.10.0"


### PR DESCRIPTION
Verwendet CSV Kalender Export Endpoint der MiDa (mit Cookie des Benutzers), um Daten zu nicht öffentlichen Events abzurufen und in der Liste anzuzeigen.

Zusätzlich werden darüber Infos zur Anmeldung zu Veranstaltungen abgerufen und in der Liste und im DetailScreen angezeigt. Es gibt eine Filteroption nach Anmeldung für die Liste.

Für manche Veranstaltungen gibt die API keine Daten aus, diese werden durch die Daten des CSV Endpoints ergänzt.

Um den Endpoint nutzen zu können wird beim App Start der Nutzer neu verifiziert. Bei falschen Daten wird der Nutzer ausgeloggt. Wenn die Verbindung zur MiDa fehlschlägt wird der Offline Modus aktiviert, der die letzten Daten anzeigt.

Dafür werden alle Veranstaltungs- und Anmeldedaten in der Datenbank gespeichert (verringert auch Wartezeit beim App Start).


Diese Implementierung löst damit auch **KJG-82 Anmeldung bei Veranstaltungen geht nicht**