### PR TITLE
Feature/kjg 70 attachments

### DIFF
--- a/lib/backend/mida_service.dart
+++ b/lib/backend/mida_service.dart
@@ -200,12 +200,12 @@ class MidaService {
     }
   }
 
-  Future<EventModel> getEvent(String id) async {
+  Future<EventModel> getEvent(String id, {String? baseUrl}) async {
     final response = await _get("${Strings.midaBaseURL}/?api=GetEvent&id=$id");
 
     if (response.statusCode == 200) {
       dynamic jsonResponse = json.decode(response.body);
-      final eventModel = EventModel.fromJson(jsonResponse);
+      final eventModel = EventModel.fromJson(jsonResponse, baseUrl: baseUrl);
       if (eventModel == null) throw const FormatException("Invalid json");
       return eventModel;
     } else {

--- a/lib/constants/strings.dart
+++ b/lib/constants/strings.dart
@@ -12,4 +12,8 @@ class Strings {
   static const midaCsvPlaceHeader = "Ort";
   static const midaCsvTitleHeader = "Veranstaltung";
   static const midaCsvDateHeader = "Datum";
+
+  static String attachmentDownloadLink(String baseUrl, String attachment) {
+    return "$baseUrl/?download=$attachment";
+  }
 }

--- a/lib/database/db_service.dart
+++ b/lib/database/db_service.dart
@@ -4,9 +4,15 @@ import 'package:kjg_muf_app/database/model/game_model.dart';
 import 'package:path_provider/path_provider.dart';
 
 class DBService {
+  static final DBService _instance = DBService._internal();
+
   late Future<Isar> db;
 
-  DBService() {
+  factory DBService() {
+    return _instance;
+  }
+
+  DBService._internal() {
     db = openDB();
   }
 
@@ -35,6 +41,11 @@ class DBService {
     final isar = await db;
     isar.writeTxn(() => isar.eventModels.clear());
     isar.writeTxn(() => isar.eventModels.putAll(events));
+  }
+
+  Future<void> saveEvent(EventModel event) async {
+    final isar = await db;
+    isar.writeTxn(() => isar.eventModels.put(event));
   }
 
   Future<Isar> openDB() async {

--- a/lib/database/model/event_model.dart
+++ b/lib/database/model/event_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:isar/isar.dart';
 import 'package:kjg_muf_app/constants/strings.dart';
 import 'package:kjg_muf_app/utils/extensions.dart';
@@ -22,6 +23,8 @@ class EventModel {
   late String? organizer;
   late String? type;
   late bool registered;
+  late String? baseUrl;
+  late DateTime? cachedTime;
 
   DateTime? get endDate =>
       startDateAndTime?.add(Duration(days: durationDays ?? 1 - 1));
@@ -63,9 +66,11 @@ class EventModel {
     this.organizer,
     this.type,
     this.registered = false,
+    this.baseUrl,
+    this.cachedTime,
   }) : id = int.parse(eventID);
 
-  static EventModel? fromJson(Map<String, dynamic> json) {
+  static EventModel? fromJson(Map<String, dynamic> json, {String? baseUrl}) {
     // match necessary json values
     if (json
         case {
@@ -85,15 +90,17 @@ class EventModel {
         endTime = timeInput.split('-')[1];
       }
 
+      baseUrl ??= json.getStringNonEmpty('url');
+
       String? eventUrl;
       String? imageUrl;
-      if (json.getStringNonEmpty('url') case String url) {
+      if (baseUrl != null) {
         if (json.getStringNonEmpty('link') case String link) {
-          eventUrl = "$url$link";
+          eventUrl = "$baseUrl$link";
         }
 
         if (json.getStringNonEmpty('bild') case String bild) {
-          imageUrl = "$url/?download=$bild";
+          imageUrl = "$baseUrl/?download=$bild";
         }
       }
 
@@ -104,7 +111,7 @@ class EventModel {
 
       List<String>? attachments;
       if (json.getStringNonEmpty('attachments') case String attachmentsString) {
-        attachmentsString
+        attachments = attachmentsString
             .split("\n")
             .where((element) => element.isNotEmpty)
             .toList();
@@ -130,6 +137,7 @@ class EventModel {
         imageUrl: imageUrl,
         organizer: json.getStringNonEmpty('verein'),
         type: json.getStringNonEmpty('typ'),
+        baseUrl: baseUrl,
       );
     }
 

--- a/lib/database/model/event_model.g.dart
+++ b/lib/database/model/event_model.g.dart
@@ -22,78 +22,98 @@ const EventModelSchema = CollectionSchema(
       name: r'attachments',
       type: IsarType.stringList,
     ),
-    r'contactEmail': PropertySchema(
+    r'baseUrl': PropertySchema(
       id: 1,
+      name: r'baseUrl',
+      type: IsarType.string,
+    ),
+    r'cachedTime': PropertySchema(
+      id: 2,
+      name: r'cachedTime',
+      type: IsarType.dateTime,
+    ),
+    r'contactEmail': PropertySchema(
+      id: 3,
       name: r'contactEmail',
       type: IsarType.string,
     ),
     r'contactName': PropertySchema(
-      id: 2,
+      id: 4,
       name: r'contactName',
       type: IsarType.string,
     ),
     r'description': PropertySchema(
-      id: 3,
+      id: 5,
       name: r'description',
       type: IsarType.string,
     ),
     r'durationDays': PropertySchema(
-      id: 4,
+      id: 6,
       name: r'durationDays',
       type: IsarType.long,
     ),
     r'endDate': PropertySchema(
-      id: 5,
+      id: 7,
       name: r'endDate',
       type: IsarType.dateTime,
     ),
     r'endTime': PropertySchema(
-      id: 6,
+      id: 8,
       name: r'endTime',
       type: IsarType.dateTime,
     ),
     r'eventID': PropertySchema(
-      id: 7,
+      id: 9,
       name: r'eventID',
       type: IsarType.string,
     ),
     r'eventUrl': PropertySchema(
-      id: 8,
+      id: 10,
       name: r'eventUrl',
       type: IsarType.string,
     ),
     r'imageUrl': PropertySchema(
-      id: 9,
+      id: 11,
       name: r'imageUrl',
       type: IsarType.string,
     ),
     r'location': PropertySchema(
-      id: 10,
+      id: 12,
       name: r'location',
       type: IsarType.string,
     ),
+    r'locationForMap': PropertySchema(
+      id: 13,
+      name: r'locationForMap',
+      type: IsarType.string,
+    ),
+    r'locationName': PropertySchema(
+      id: 14,
+      name: r'locationName',
+      type: IsarType.string,
+    ),
     r'organizer': PropertySchema(
-      id: 11,
+      id: 15,
       name: r'organizer',
       type: IsarType.string,
     ),
     r'registered': PropertySchema(
-      id: 12,
+      id: 16,
       name: r'registered',
       type: IsarType.bool,
     ),
     r'startDateAndTime': PropertySchema(
-      id: 13,
+      id: 17,
       name: r'startDateAndTime',
       type: IsarType.dateTime,
     ),
     r'title': PropertySchema(
-      id: 14,
+      id: 18,
       name: r'title',
       type: IsarType.string,
     ),
     r'type': PropertySchema(
-      id: 15,
+      id: 19,
       name: r'type',
       type: IsarType.string,
     )
@@ -128,6 +148,12 @@ int _eventModelEstimateSize(
           bytesCount += value.length * 3;
         }
       }
+    }
+  }
+  {
+    final value = object.baseUrl;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
     }
   }
   {
@@ -168,6 +194,18 @@ int _eventModelEstimateSize(
     }
   }
   {
+    final value = object.locationForMap;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.locationName;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.organizer;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -190,21 +228,25 @@ void _eventModelSerialize(
   Map<Type, List<int>> allOffsets,
 ) {
   writer.writeStringList(offsets[0], object.attachments);
-  writer.writeString(offsets[1], object.contactEmail);
-  writer.writeString(offsets[2], object.contactName);
-  writer.writeString(offsets[3], object.description);
-  writer.writeLong(offsets[4], object.durationDays);
-  writer.writeDateTime(offsets[5], object.endDate);
-  writer.writeDateTime(offsets[6], object.endTime);
-  writer.writeString(offsets[7], object.eventID);
-  writer.writeString(offsets[8], object.eventUrl);
-  writer.writeString(offsets[9], object.imageUrl);
-  writer.writeString(offsets[10], object.location);
-  writer.writeString(offsets[11], object.organizer);
-  writer.writeBool(offsets[12], object.registered);
-  writer.writeDateTime(offsets[13], object.startDateAndTime);
-  writer.writeString(offsets[14], object.title);
-  writer.writeString(offsets[15], object.type);
+  writer.writeString(offsets[1], object.baseUrl);
+  writer.writeDateTime(offsets[2], object.cachedTime);
+  writer.writeString(offsets[3], object.contactEmail);
+  writer.writeString(offsets[4], object.contactName);
+  writer.writeString(offsets[5], object.description);
+  writer.writeLong(offsets[6], object.durationDays);
+  writer.writeDateTime(offsets[7], object.endDate);
+  writer.writeDateTime(offsets[8], object.endTime);
+  writer.writeString(offsets[9], object.eventID);
+  writer.writeString(offsets[10], object.eventUrl);
+  writer.writeString(offsets[11], object.imageUrl);
+  writer.writeString(offsets[12], object.location);
+  writer.writeString(offsets[13], object.locationForMap);
+  writer.writeString(offsets[14], object.locationName);
+  writer.writeString(offsets[15], object.organizer);
+  writer.writeBool(offsets[16], object.registered);
+  writer.writeDateTime(offsets[17], object.startDateAndTime);
+  writer.writeString(offsets[18], object.title);
+  writer.writeString(offsets[19], object.type);
 }
 
 EventModel _eventModelDeserialize(
@@ -215,20 +257,22 @@ EventModel _eventModelDeserialize(
 ) {
   final object = EventModel(
     attachments: reader.readStringList(offsets[0]),
-    contactEmail: reader.readStringOrNull(offsets[1]),
-    contactName: reader.readStringOrNull(offsets[2]),
-    description: reader.readStringOrNull(offsets[3]),
-    durationDays: reader.readLongOrNull(offsets[4]),
-    endTime: reader.readDateTimeOrNull(offsets[6]),
-    eventID: reader.readString(offsets[7]),
-    eventUrl: reader.readStringOrNull(offsets[8]),
-    imageUrl: reader.readStringOrNull(offsets[9]),
-    location: reader.readStringOrNull(offsets[10]),
-    organizer: reader.readStringOrNull(offsets[11]),
-    registered: reader.readBoolOrNull(offsets[12]) ?? false,
-    startDateAndTime: reader.readDateTimeOrNull(offsets[13]),
-    title: reader.readString(offsets[14]),
-    type: reader.readStringOrNull(offsets[15]),
+    baseUrl: reader.readStringOrNull(offsets[1]),
+    cachedTime: reader.readDateTimeOrNull(offsets[2]),
+    contactEmail: reader.readStringOrNull(offsets[3]),
+    contactName: reader.readStringOrNull(offsets[4]),
+    description: reader.readStringOrNull(offsets[5]),
+    durationDays: reader.readLongOrNull(offsets[6]),
+    endTime: reader.readDateTimeOrNull(offsets[8]),
+    eventID: reader.readString(offsets[9]),
+    eventUrl: reader.readStringOrNull(offsets[10]),
+    imageUrl: reader.readStringOrNull(offsets[11]),
+    location: reader.readStringOrNull(offsets[12]),
+    organizer: reader.readStringOrNull(offsets[15]),
+    registered: reader.readBoolOrNull(offsets[16]) ?? false,
+    startDateAndTime: reader.readDateTimeOrNull(offsets[17]),
+    title: reader.readString(offsets[18]),
+    type: reader.readStringOrNull(offsets[19]),
   );
   object.id = id;
   return object;
@@ -246,32 +290,40 @@ P _eventModelDeserializeProp<P>(
     case 1:
       return (reader.readStringOrNull(offset)) as P;
     case 2:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDateTimeOrNull(offset)) as P;
     case 3:
       return (reader.readStringOrNull(offset)) as P;
     case 4:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 5:
-      return (reader.readDateTimeOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 6:
-      return (reader.readDateTimeOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 7:
-      return (reader.readString(offset)) as P;
+      return (reader.readDateTimeOrNull(offset)) as P;
     case 8:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readDateTimeOrNull(offset)) as P;
     case 9:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 10:
       return (reader.readStringOrNull(offset)) as P;
     case 11:
       return (reader.readStringOrNull(offset)) as P;
     case 12:
-      return (reader.readBoolOrNull(offset) ?? false) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 13:
-      return (reader.readDateTimeOrNull(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 14:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 15:
+      return (reader.readStringOrNull(offset)) as P;
+    case 16:
+      return (reader.readBoolOrNull(offset) ?? false) as P;
+    case 17:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 18:
+      return (reader.readString(offset)) as P;
+    case 19:
       return (reader.readStringOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -609,6 +661,228 @@ extension EventModelQueryFilter
         upper,
         includeUpper,
       );
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'baseUrl',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      baseUrlIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'baseUrl',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      baseUrlGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'baseUrl',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'baseUrl',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'baseUrl',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> baseUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'baseUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      baseUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'baseUrl',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      cachedTimeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedTime',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      cachedTimeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedTime',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> cachedTimeEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      cachedTimeGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      cachedTimeLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedTime',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition> cachedTimeBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedTime',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
     });
   }
 
@@ -1929,6 +2203,314 @@ extension EventModelQueryFilter
   }
 
   QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'locationForMap',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'locationForMap',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'locationForMap',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'locationForMap',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'locationForMap',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'locationForMap',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationForMapIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'locationForMap',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'locationName',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'locationName',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'locationName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'locationName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'locationName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'locationName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
+      locationNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'locationName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterFilterCondition>
       organizerIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -2450,6 +3032,30 @@ extension EventModelQueryLinks
 
 extension EventModelQuerySortBy
     on QueryBuilder<EventModel, EventModel, QSortBy> {
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByBaseUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByBaseUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByCachedTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByCachedTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedTime', Sort.desc);
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByContactEmail() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'contactEmail', Sort.asc);
@@ -2570,6 +3176,31 @@ extension EventModelQuerySortBy
     });
   }
 
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByLocationForMap() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationForMap', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy>
+      sortByLocationForMapDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationForMap', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByLocationName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByLocationNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationName', Sort.desc);
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QAfterSortBy> sortByOrganizer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'organizer', Sort.asc);
@@ -2634,6 +3265,30 @@ extension EventModelQuerySortBy
 
 extension EventModelQuerySortThenBy
     on QueryBuilder<EventModel, EventModel, QSortThenBy> {
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByBaseUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByBaseUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByCachedTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedTime', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByCachedTimeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedTime', Sort.desc);
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByContactEmail() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'contactEmail', Sort.asc);
@@ -2766,6 +3421,31 @@ extension EventModelQuerySortThenBy
     });
   }
 
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByLocationForMap() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationForMap', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy>
+      thenByLocationForMapDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationForMap', Sort.desc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByLocationName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByLocationNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'locationName', Sort.desc);
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QAfterSortBy> thenByOrganizer() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'organizer', Sort.asc);
@@ -2836,6 +3516,19 @@ extension EventModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByBaseUrl(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'baseUrl', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByCachedTime() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedTime');
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QDistinct> distinctByContactEmail(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -2903,6 +3596,21 @@ extension EventModelQueryWhereDistinct
     });
   }
 
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByLocationForMap(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'locationForMap',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<EventModel, EventModel, QDistinct> distinctByLocationName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'locationName', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<EventModel, EventModel, QDistinct> distinctByOrganizer(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -2949,6 +3657,18 @@ extension EventModelQueryProperty
       attachmentsProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'attachments');
+    });
+  }
+
+  QueryBuilder<EventModel, String?, QQueryOperations> baseUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'baseUrl');
+    });
+  }
+
+  QueryBuilder<EventModel, DateTime?, QQueryOperations> cachedTimeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedTime');
     });
   }
 
@@ -3009,6 +3729,18 @@ extension EventModelQueryProperty
   QueryBuilder<EventModel, String?, QQueryOperations> locationProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'location');
+    });
+  }
+
+  QueryBuilder<EventModel, String?, QQueryOperations> locationForMapProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'locationForMap');
+    });
+  }
+
+  QueryBuilder<EventModel, String?, QQueryOperations> locationNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'locationName');
     });
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -37,6 +37,17 @@
         "example": "Cosmas"
       }
     }
-  }
+  },
+
+  "dontAskAgain": "Nicht erneut nachfragen",
+  "download": "Herunterladen",
+  "downloadDescription": "Alle Anhänge dieser Veranstaltung für 90 Tage in der App offline verfügbar machen",
+  "cancel": "Abbrechen",
+  "ok": "OK",
+  "error": "Fehler",
+  "fileErrorDescription": "Es können aktuell nur PDF Dateien oder Bilder geöffnet werden",
+  "delete": "Löschen",
+  "deleteDescription": "Die Anhänge sind dann nicht mehr offline verfügbar",
+  "attachments": "Dateien"
 
 }

--- a/lib/model/csv_event.dart
+++ b/lib/model/csv_event.dart
@@ -5,6 +5,7 @@ class CSVEvent {
   final String eventID;
   final bool registered;
   final String link;
+  final String baseUrl;
 
   CSVEvent({
     required this.eventID,
@@ -13,6 +14,7 @@ class CSVEvent {
     required this.startTime,
     required this.place,
     required this.link,
+    required this.baseUrl,
   });
 
   @override

--- a/lib/ui/screens/event_detail_screen.dart
+++ b/lib/ui/screens/event_detail_screen.dart
@@ -11,6 +11,7 @@ import 'package:kjg_muf_app/ui/screens/fullscreen_image.dart';
 import 'package:kjg_muf_app/ui/screens/mida_webview_screen.dart';
 import 'package:kjg_muf_app/ui/widgets/attachments_widget.dart';
 import 'package:kjg_muf_app/ui/widgets/event_item.dart';
+import 'package:kjg_muf_app/utils/cache_manager.dart';
 import 'package:kjg_muf_app/utils/extensions.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 import 'package:kjg_muf_app/viewmodels/event.detail.viewmodel.dart';
@@ -238,13 +239,7 @@ class EventDetailScreen extends StatelessWidget {
                               clipBehavior: Clip.antiAlias,
                               child: AspectRatio(
                                 aspectRatio: 1,
-                                child: Stack(
-                                  alignment: Alignment.center,
-                                  children: [
-                                    const CircularProgressIndicator(),
-                                    Image.network(event.imageUrl!),
-                                  ],
-                                ),
+                                child: _getImageCached(context),
                               ),
                             ),
                           ),
@@ -284,8 +279,13 @@ class EventDetailScreen extends StatelessWidget {
                             ),
                           ),
                         if (event.attachments != null &&
-                            event.attachments!.isNotEmpty)
-                          attachmentsWidget(context, event.attachments!),
+                            event.attachments!.isNotEmpty &&
+                            event.baseUrl != null)
+                          AttachmentsWidget(
+                            baseUrl: event.baseUrl!,
+                            attachments: event.attachments!,
+                            cachedTime: event.cachedTime,
+                          ),
                       ],
                     ),
                   ),
@@ -334,6 +334,21 @@ class EventDetailScreen extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+
+  Widget _getImageCached(BuildContext context) {
+    return FutureBuilder(
+      future: KjGCacheManager.instance.getSingleFile(event.imageUrl!),
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          return Image(
+            image: FileImage(snapshot.data!.absolute),
+          );
+        }
+
+        return const Center(child: CircularProgressIndicator());
+      },
     );
   }
 }

--- a/lib/ui/screens/fullscreen_image.dart
+++ b/lib/ui/screens/fullscreen_image.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/file.dart';
+import 'package:kjg_muf_app/utils/cache_manager.dart';
 import 'package:photo_view/photo_view.dart';
 
 class FullscreenImage extends StatelessWidget {
@@ -10,13 +12,23 @@ class FullscreenImage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: PhotoView(
-        backgroundDecoration: BoxDecoration(
-          color: Theme.of(context).scaffoldBackgroundColor,
-        ),
-        minScale: PhotoViewComputedScale.contained,
-        maxScale: PhotoViewComputedScale.covered * 2,
-        imageProvider: NetworkImage(url),
+      body: FutureBuilder<File>(
+        future: KjGCacheManager.instance.getSingleFile(url),
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            return PhotoView(
+              backgroundDecoration: BoxDecoration(
+                color: Theme.of(context).scaffoldBackgroundColor,
+              ),
+              minScale: PhotoViewComputedScale.contained,
+              maxScale: PhotoViewComputedScale.covered * 2,
+              imageProvider: FileImage(snapshot.data!.absolute),
+            );
+          }
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        },
       ),
     );
   }

--- a/lib/ui/screens/pdf_screen.dart
+++ b/lib/ui/screens/pdf_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:kjg_muf_app/utils/cache_manager.dart';
 
 class PDFScreen extends StatelessWidget {
   final String pdfLink;
@@ -17,7 +18,7 @@ class PDFScreen extends StatelessWidget {
         title: Text(pageTitle),
       ),
       body: FutureBuilder<File>(
-        future: DefaultCacheManager().getSingleFile(pdfLink),
+        future: KjGCacheManager.instance.getSingleFile(pdfLink),
         builder: (context, snapshot) => snapshot.hasData
             ? PDFView(
                 fitPolicy: FitPolicy.WIDTH,

--- a/lib/ui/widgets/attachments_widget.dart
+++ b/lib/ui/widgets/attachments_widget.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/constants/strings.dart';
 import 'package:kjg_muf_app/ui/screens/fullscreen_image.dart';
 import 'package:kjg_muf_app/ui/screens/pdf_screen.dart';
-import 'package:kjg_muf_app/utils/cache_manager.dart';
+import 'package:kjg_muf_app/ui/widgets/download_dialog.dart';
 import 'package:kjg_muf_app/viewmodels/event.detail.viewmodel.dart';
 import 'package:mime/mime.dart';
 import 'package:provider/provider.dart';
+import 'package:kjg_muf_app/utils/extensions.dart';
 
 class AttachmentsWidget extends StatelessWidget {
   final String baseUrl;
@@ -32,7 +33,10 @@ class AttachmentsWidget extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  const Text("Dateien", style: TextStyle(fontSize: 16)),
+                  Text(
+                    context.localizations.attachments,
+                    style: const TextStyle(fontSize: 16),
+                  ),
                   _iconButton(context),
                 ],
               ),
@@ -92,12 +96,12 @@ class AttachmentsWidget extends StatelessWidget {
   _showDeleteDialog(BuildContext context, EventDetailViewModel viewModel) {
     _showAlertDialog(
       context,
-      "Löschen",
-      "Möchtest du die Anhänge wirklich nicht mehr offline verfügbar haben?",
+      context.localizations.delete,
+      context.localizations.deleteDescription,
       okAction: () {
         viewModel.deleteAttachments();
       },
-      okText: "Löschen",
+      okText: context.localizations.delete,
       withCancel: true,
     );
   }
@@ -136,8 +140,8 @@ class AttachmentsWidget extends StatelessWidget {
     if (fileType.isUnsupported) {
       _showAlertDialog(
         context,
-        "Fehler",
-        "Es können aktuell nur PDF Dateien oder Bilder geöffnet werden",
+        context.localizations.error,
+        context.localizations.fileErrorDescription,
       );
       return;
     }
@@ -164,10 +168,12 @@ class AttachmentsWidget extends StatelessWidget {
     BuildContext context,
     String title,
     String message, {
-    String okText = "OK",
+    String? okText,
     Function()? okAction,
     bool withCancel = false,
   }) {
+    okText ??= context.localizations.ok;
+
     // set up the button
     Widget okButton = TextButton(
       onPressed: () {
@@ -188,7 +194,7 @@ class AttachmentsWidget extends StatelessWidget {
             onPressed: () {
               Navigator.of(context).pop();
             },
-            child: const Text("Abbrechen"),
+            child: Text(context.localizations.cancel),
           ),
       ],
     );
@@ -224,72 +230,4 @@ enum FileType {
   bool get isImage => this == FileType.image;
 
   bool get isUnsupported => this == FileType.unsupported;
-}
-
-class DownloadDialog extends StatefulWidget {
-  final Function(bool) downloadAction;
-
-  const DownloadDialog({
-    super.key,
-    required this.downloadAction,
-  });
-
-  @override
-  State<DownloadDialog> createState() => _DownloadDialogState();
-}
-
-class _DownloadDialogState extends State<DownloadDialog> {
-  bool _showDownloadDialog = true;
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: const Text("Herunterladen"),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Text(
-            "Alle Anhänge für 90 Tage in der App offline verfügbar machen",
-          ),
-          const SizedBox(
-            height: 10,
-          ),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Switch(
-                value: _showDownloadDialog,
-                onChanged: (newValue) {
-                  setState(() {
-                    _showDownloadDialog = newValue;
-                  });
-                },
-              ),
-              const SizedBox(
-                width: 10,
-              ),
-              const Text("Nicht erneut nachfragen"),
-            ],
-          ),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: () {
-            widget.downloadAction(
-              _showDownloadDialog,
-            );
-            Navigator.of(context).pop();
-          },
-          child: const Text("Herunterladen"),
-        ),
-        TextButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
-          child: const Text("Abbrechen"),
-        ),
-      ],
-    );
-  }
 }

--- a/lib/ui/widgets/attachments_widget.dart
+++ b/lib/ui/widgets/attachments_widget.dart
@@ -1,69 +1,182 @@
 import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/constants/strings.dart';
+import 'package:kjg_muf_app/ui/screens/fullscreen_image.dart';
 import 'package:kjg_muf_app/ui/screens/pdf_screen.dart';
+import 'package:kjg_muf_app/utils/cache_manager.dart';
+import 'package:kjg_muf_app/viewmodels/event.detail.viewmodel.dart';
+import 'package:mime/mime.dart';
+import 'package:provider/provider.dart';
 
-Widget attachmentsWidget(BuildContext context, List<String> attachments) {
-  return Card(
-    child: SizedBox(
-      width: double.infinity,
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text("Dateien", style: TextStyle(fontSize: 16)),
-            const SizedBox(height: 4),
-            ...attachments.map((e) {
-              bool isPDF = e.endsWith('.pdf');
-              String fileTitle = e.substring(e.indexOf('_') + 1);
+class AttachmentsWidget extends StatelessWidget {
+  final String baseUrl;
+  final List<String> attachments;
+  final DateTime? cachedTime;
 
-              return ListTile(
-                title: Text(fileTitle),
-                leading:
-                    Icon(isPDF ? Icons.picture_as_pdf : Icons.question_mark),
-                onTap: () {
-                  if (isPDF) {
-                    Navigator.of(context).push(MaterialPageRoute(
-                        builder: (context) => PDFScreen(
-                            pdfLink: "${Strings.midaBaseURL}/?download=$e",
-                            pageTitle: fileTitle)));
-                  } else {
-                    showAlertDialog(context, "Fehler",
-                        "Es können aktuell nur PDF Dateien geöffnet werden");
-                  }
-                },
-              );
-            })
-          ],
+  const AttachmentsWidget({
+    super.key,
+    required this.attachments,
+    required this.baseUrl,
+    this.cachedTime,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text("Dateien", style: TextStyle(fontSize: 16)),
+                  _iconButton(context),
+                ],
+              ),
+              const SizedBox(height: 4),
+              ..._getAttachments(context),
+            ],
+          ),
         ),
       ),
-    ),
-  );
+    );
+  }
+
+  Widget _iconButton(BuildContext context) {
+    final viewModel = Provider.of<EventDetailViewModel>(context, listen: false);
+
+    if (viewModel.loadingAttachments) {
+      return const IconButton(
+        onPressed: null,
+        icon: SizedBox(
+          width: 12,
+          height: 12,
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (cachedTime == null) {
+      return IconButton(
+        onPressed: () => viewModel.cacheAttachments(),
+        icon: const Icon(Icons.download),
+      );
+    }
+
+    return IconButton(
+      onPressed: () => viewModel.deleteAttachments(),
+      icon: const Icon(Icons.delete),
+    );
+  }
+
+  Iterable<Widget> _getAttachments(BuildContext context) {
+    return attachments.map((e) {
+      return _attachment(context, e);
+    });
+  }
+
+  Widget _attachment(BuildContext context, String attachment) {
+    final fileType = FileType.getFileType(attachment);
+
+    String fileTitle = fileType.isPdf
+        ? attachment.substring(attachment.indexOf('_') + 1)
+        : attachment;
+    final icon = switch (fileType) {
+      FileType.pdf => Icons.picture_as_pdf,
+      FileType.image => Icons.image,
+      FileType.unsupported => Icons.question_mark,
+    };
+
+    return ListTile(
+      title: Text(fileTitle),
+      leading: Icon(icon),
+      onTap: () => _openFile(context, attachment, fileTitle, fileType),
+    );
+  }
+
+  _openFile(
+    BuildContext context,
+    String attachment,
+    String fileTitle,
+    FileType fileType,
+  ) {
+    if (fileType.isUnsupported) {
+      showAlertDialog(
+        context,
+        "Fehler",
+        "Es können aktuell nur PDF Dateien oder Bilder geöffnet werden",
+      );
+      return;
+    }
+
+    final url = Strings.attachmentDownloadLink(baseUrl, attachment);
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) {
+          return switch (fileType) {
+            FileType.pdf => PDFScreen(
+                pdfLink: url,
+                pageTitle: fileTitle,
+              ),
+            FileType.image => FullscreenImage(url: url),
+            FileType.unsupported => throw UnimplementedError(),
+          };
+        },
+      ),
+    );
+  }
+
+  showAlertDialog(BuildContext context, String title, String message) {
+    // set up the button
+    Widget okButton = TextButton(
+      child: const Text("OK"),
+      onPressed: () {
+        Navigator.of(context).pop();
+      },
+    );
+
+    // set up the AlertDialog
+    AlertDialog alert = AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        okButton,
+      ],
+    );
+
+    // show the dialog
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
+  }
 }
 
-showAlertDialog(BuildContext context, String title, String message) {
-  // set up the button
-  Widget okButton = TextButton(
-    child: const Text("OK"),
-    onPressed: () {
-      Navigator.of(context).pop();
-    },
-  );
+enum FileType {
+  pdf,
+  image,
+  unsupported;
 
-  // set up the AlertDialog
-  AlertDialog alert = AlertDialog(
-    title: Text(title),
-    content: Text(message),
-    actions: [
-      okButton,
-    ],
-  );
+  static FileType getFileType(String fileName) {
+    final mimeType = lookupMimeType(fileName);
 
-  // show the dialog
-  showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return alert;
-    },
-  );
+    if (mimeType == null) return FileType.unsupported;
+
+    if (mimeType.startsWith("image")) return FileType.image;
+    if (mimeType == "application/pdf") return FileType.pdf;
+
+    return FileType.unsupported;
+  }
+
+  bool get isPdf => this == FileType.pdf;
+
+  bool get isImage => this == FileType.image;
+
+  bool get isUnsupported => this == FileType.unsupported;
 }

--- a/lib/ui/widgets/download_dialog.dart
+++ b/lib/ui/widgets/download_dialog.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:kjg_muf_app/utils/extensions.dart';
+
+class DownloadDialog extends StatefulWidget {
+  final Function(bool) downloadAction;
+
+  const DownloadDialog({
+    super.key,
+    required this.downloadAction,
+  });
+
+  @override
+  State<DownloadDialog> createState() => _DownloadDialogState();
+}
+
+class _DownloadDialogState extends State<DownloadDialog> {
+  bool _showDownloadDialog = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(context.localizations.download),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(context.localizations.downloadDescription),
+          const SizedBox(
+            height: 10,
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Switch(
+                value: _showDownloadDialog,
+                onChanged: (newValue) {
+                  setState(() {
+                    _showDownloadDialog = newValue;
+                  });
+                },
+              ),
+              const SizedBox(
+                width: 10,
+              ),
+              Text(context.localizations.dontAskAgain),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            widget.downloadAction(
+              _showDownloadDialog,
+            );
+            Navigator.of(context).pop();
+          },
+          child: Text(context.localizations.download),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(context.localizations.cancel),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/utils/cache_manager.dart
+++ b/lib/utils/cache_manager.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+class KjGCacheManager {
+  static const key = 'kjgCacheKey';
+
+  static CacheManager instance = CacheManager(
+    Config(
+      key,
+      stalePeriod: const Duration(days: 90),
+      maxNrOfCacheObjects: 100,
+    ),
+  );
+}

--- a/lib/utils/cache_manager.dart
+++ b/lib/utils/cache_manager.dart
@@ -7,7 +7,7 @@ class KjGCacheManager {
     Config(
       key,
       stalePeriod: const Duration(days: 90),
-      maxNrOfCacheObjects: 100,
+      maxNrOfCacheObjects: 1000,
     ),
   );
 }

--- a/lib/utils/csv_helper.dart
+++ b/lib/utils/csv_helper.dart
@@ -46,6 +46,7 @@ class CSVHelper {
       if (idStart != -1) {
         String id =
             link.substring(idStart + 14, idEnd == -1 ? link.length : idEnd);
+        String baseUrl = link.substring(0, idStart - 1);
 
         String date = (row[dateIndex] as String).substring(3);
 
@@ -72,6 +73,7 @@ class CSVHelper {
             startTime: d,
             place: row[placeIndex],
             link: row[linkIndex],
+            baseUrl: baseUrl,
           ),
         );
       }

--- a/lib/utils/shared_prefs.dart
+++ b/lib/utils/shared_prefs.dart
@@ -24,6 +24,7 @@ class SharedPref {
   static const keyUeberEbene = "key.ueberebene";
   static const keyEbene = "key.ebene";
   static const keyMitgliedsNummer = "key.mitgliedsnummer";
+  static const keyDownloadDialog = "key.download";
 
   Future<void> saveName(String fullName) async {
     var prefs = await SharedPreferences.getInstance();
@@ -147,5 +148,15 @@ class SharedPref {
   Future<String?> getMitgliedsNummer() async {
     var prefs = await SharedPreferences.getInstance();
     return prefs.getString(keyMitgliedsNummer);
+  }
+
+  Future<void> setDownloadDialog(bool newValue) async {
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(keyDownloadDialog, newValue);
+  }
+
+  Future<bool?> getDownloadDialog() async {
+    var prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(keyDownloadDialog);
   }
 }

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -18,6 +18,7 @@ class EventDetailViewModel extends ChangeNotifier {
 
   final EventModel event;
   final bool offline;
+  bool _showDownloadDialog = true;
 
   Location? _location;
 
@@ -26,6 +27,8 @@ class EventDetailViewModel extends ChangeNotifier {
   GeolocationState _geolocationState = GeolocationState.loading;
 
   GeolocationState get geolocationState => _geolocationState;
+
+  bool get showDownloadDialog => _showDownloadDialog;
 
   bool loadingAttachments = false;
 
@@ -36,6 +39,15 @@ class EventDetailViewModel extends ChangeNotifier {
       _geolocationState = GeolocationState.error;
     }
     refreshUserRegisteredForEvent(event.eventID);
+
+    _init();
+  }
+
+  _init() async {
+    _showDownloadDialog = await SharedPref().getDownloadDialog() ?? true;
+    if (!_showDownloadDialog) {
+      notifyListeners();
+    }
   }
 
   getLocationFromAddress(EventModel event) async {
@@ -95,7 +107,9 @@ class EventDetailViewModel extends ChangeNotifier {
     }
   }
 
-  cacheAttachments() async {
+  cacheAttachments(bool showDownloadDialog) async {
+    SharedPref().setDownloadDialog(showDownloadDialog);
+
     loadingAttachments = true;
     notifyListeners();
 

--- a/lib/viewmodels/event.detail.viewmodel.dart
+++ b/lib/viewmodels/event.detail.viewmodel.dart
@@ -107,16 +107,20 @@ class EventDetailViewModel extends ChangeNotifier {
       futures.add(KjGCacheManager.instance.downloadFile(url));
     }
 
-    Future.wait(futures, eagerError: true).then((value) {
-      event.cachedTime = DateTime.now();
-      DBService().saveEvent(event);
-      loadingAttachments = false;
+    Future.wait(futures, eagerError: true).then(
+      (value) {
+        event.cachedTime = DateTime.now();
+        DBService().saveEvent(event);
+        loadingAttachments = false;
 
-      notifyListeners();
-    }).catchError((error, stackTrace) {
-      // do nothing, probably no internet
-      loadingAttachments = false;
-    });
+        notifyListeners();
+      },
+      onError: (error, stackTrace) {
+        // do nothing, probably no internet
+        loadingAttachments = false;
+        notifyListeners();
+      },
+    );
   }
 
   deleteAttachments() {

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:kjg_muf_app/backend/mida_service.dart';
+import 'package:kjg_muf_app/constants/strings.dart';
 import 'package:kjg_muf_app/database/db_service.dart';
 import 'package:kjg_muf_app/database/model/event_model.dart';
 import 'package:kjg_muf_app/model/csv_event.dart';
 import 'package:kjg_muf_app/model/filter_settings.dart';
+import 'package:kjg_muf_app/utils/cache_manager.dart';
 import 'package:kjg_muf_app/utils/shared_prefs.dart';
 
 class EventListViewModel extends ChangeNotifier {
@@ -42,9 +44,11 @@ class EventListViewModel extends ChangeNotifier {
     }
 
     e = e
-        ?.where((element) =>
-            _filterSettings.showOrganizer[element.organizer ?? "Unbekannt"] ??
-            true)
+        ?.where(
+          (element) =>
+              _filterSettings.showOrganizer[element.organizer ?? "Unbekannt"] ??
+              true,
+        )
         .toList();
 
     if (_filterSettings.dateTimeRange != null) {
@@ -91,6 +95,20 @@ class EventListViewModel extends ChangeNotifier {
     for (EventModel eM in eventModels) {
       if (eM.startDateAndTime?.isAfter(startOfToday) ?? false) {
         _events?.add(eM);
+      } else {
+        // delete cached attachments for old event
+        if (eM.baseUrl case String baseUrl) {
+          eM.attachments?.forEach((element) {
+            KjGCacheManager.instance.removeFile(
+              Strings.attachmentDownloadLink(baseUrl, element),
+            );
+          });
+        }
+
+        // delete event image
+        if (eM.imageUrl case String imageUrl) {
+          KjGCacheManager.instance.removeFile(imageUrl);
+        }
       }
     }
     notifyListeners();
@@ -113,7 +131,8 @@ class EventListViewModel extends ChangeNotifier {
         if (!publicEventIDs.contains(event.eventID)) {
           try {
             // getEvent sometimes empty... catch while investigating
-            final backendEvent = await MidaService().getEvent(event.eventID);
+            var backendEvent = await MidaService()
+                .getEvent(event.eventID, baseUrl: event.baseUrl);
             eNN.add(backendEvent);
           } catch (e) {
             // display event with basic information instead

--- a/lib/viewmodels/event.list.viewmodel.dart
+++ b/lib/viewmodels/event.list.viewmodel.dart
@@ -115,6 +115,11 @@ class EventListViewModel extends ChangeNotifier {
   }
 
   Future<void> loadEvents(bool loggedIn) async {
+    Map<int, EventModel> cachedEvents = {};
+    _events?.forEach((element) {
+      cachedEvents[element.id] = element;
+    });
+
     _events = await MidaService().getEvents();
 
     if (_events != null && loggedIn) {
@@ -171,7 +176,8 @@ class EventListViewModel extends ChangeNotifier {
       }
 
       _events = eNN
-          .map((e) => e..registered = registeredMap[e.eventID] ?? false)
+          .map((e) => (e..registered = registeredMap[e.eventID] ?? false)
+            ..cachedTime = cachedEvents[e.id]?.cachedTime)
           .toList();
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   photo_view: ^0.14.0
   csv: ^5.1.1
   flip_card: ^0.7.0
+  mime: ^1.0.5
 
 dev_dependencies:
   flutter_launcher_icons: "^0.10.0"


### PR DESCRIPTION
Fix:

- Attachments werden wieder gespeichert (hatte ich kaputt gemacht)

Neu:

- Attachment Bilder können angezeigt werden
- Attachments und Bilder werden 90 Tage gecached
- Cache Einträge für vergangene Veranstaltungen werden gelöscht
- Download Knopf, um alle attachments für ein Event gleichzeitig zu cachen (bzw. zu löschen)
 
Da der getEvent Endpunkt keine URL zurückgibt habe ich dort einen Workaround. Den verwenden wir nur für private Veranstaltungen, die wir über das CSV laden, von dort gebe ich dann die baseUrl die wir für attachments und Bilder brauchen weiter.